### PR TITLE
test: add option for keep the test container 

### DIFF
--- a/integrations/Taskfile.yaml
+++ b/integrations/Taskfile.yaml
@@ -181,13 +181,15 @@ tasks:
 
   test:gateway:
     desc: Gateway test
+    vars:
+      REMOVE_CONTAINERS: '{{ .REMOVE_CONTAINERS | default "true" }}'
     cmds:
       - task: k8s:port-forward:setup:gateway
       - defer: { task: k8s:port-forward:teardown:gateway }
       - task: test:autogen-agent:run
       - defer: { task: test:autogen-agent:remove }
       - docker pull {{ .IMAGE_REPO }}/csit/test-langchain-agent:{{ .TEST_APP_TAG }}
-      - IMAGE_REPO={{.IMAGE_REPO}} TEST_APP_TAG={{.TEST_APP_TAG}} go test ./agntcy-agp/tests -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 30m -timeout 30m -ginkgo.v
+      - REMOVE_CONTAINERS={{.REMOVE_CONTAINERS}} IMAGE_REPO={{.IMAGE_REPO}} TEST_APP_TAG={{.TEST_APP_TAG}} go test ./agntcy-agp/tests -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 30m -timeout 30m -ginkgo.v
 
   version:
     desc: Get version

--- a/integrations/testutils/docker_runner.go
+++ b/integrations/testutils/docker_runner.go
@@ -6,6 +6,7 @@ package testutils
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 )
@@ -18,7 +19,12 @@ type DockerRunner struct {
 func NewDockerRunner(dockerImage, mountString string, envVars map[string]string) *DockerRunner {
 	baseArgs := []string{
 		"run",
-		"--rm",
+	}
+
+	if os.Getenv("REMOVE_CONTAINERS") == "true" {
+		baseArgs = append(baseArgs,
+			"--rm",
+		)
 	}
 
 	if mountString != "" {


### PR DESCRIPTION
This can be useful for debugging and checking logs

example usage:
```
cd integrations
task kind:create
task test:env:gateway:deploy
task test:gateway REMOVE_CONTAINERS=false

docker ps -a
CONTAINER ID   IMAGE                                             COMMAND                  CREATED          STATUS                      PORTS                       NAMES
fad3fddf8e0f   ghcr.io/agntcy/csit/test-langchain-agent:v0.0.1   "poetry run python l…"   23 seconds ago   Exited (0) 15 seconds ago                               reverent_galileo
4a98dd9c08ce   kindest/node:v1.32.0                              "/usr/local/bin/entr…"   19 hours ago     Up 19 hours                 127.0.0.1:65285->6443/tcp   agntcy-test-control-plane

docker logs fad3fddf8e0f
```