### PR TITLE
chore: don't use submodule

### DIFF
--- a/.github/workflows/test-integrations.yaml
+++ b/.github/workflows/test-integrations.yaml
@@ -91,7 +91,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'true'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "integrations/agntcy-dir/examples/dir"]
-	path = integrations/agntcy-dir/examples/dir
-	url = https://github.com/agntcy/dir

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   - [How to extend tests with your own test](#how-to-extend-tests-with-your-own-test)
 - [Samples](#samples)
   - [Running tests](#running-tests-1)
-  - [Copyright Notice](#copyright-notice)
+- [Updating the `agntcy/dir` testdata](#updating-the-agntcydir-testdata)
+- [Copyright Notice](#copyright-notice)
 
 ## Architecture
 
@@ -242,6 +243,19 @@ It requires the followings on local machine:
 ```bash
 cd samples/[app-name]
 task run:test
+```
+
+## Updating the agntcy/dir testdata
+
+If we want to update the `integrations/agntcy-dir/examples/dir/e2e/testdata` directory we will need to add `agntcy/dir` as a remote and create a patch for it by diffing with the `agntcy/dir` repo
+
+```bash
+# add agntcy/dir as remote
+git remote add -f dir https://github.com/agntcy/dir.git
+# fetch dir
+git fetch dir
+# example of updating the integrations/agntcy-dir/examples/dir/e2e/testdata directory to the agntcy/dir main
+git diff --binary HEAD:integrations/agntcy-dir/examples/dir/e2e/testdata dir/main:e2e/testdata | git apply --directory=integrations/agntcy-dir/examples/dir/e2e/testdata
 ```
 
 ## Copyright Notice

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.base.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.base.json
@@ -1,0 +1,57 @@
+{
+  "name": "directory.agntcy.org/cisco/marketing-strategy",
+  "version": "v1.0.0",
+  "authors": [
+    "Cisco Systems"
+  ],
+  "created_at": "2025-03-19T17:06:37Z",
+  "annotations": {
+    "key": "value"
+  },
+  "skills": [
+    {
+      "category_name": "Natural Language Processing",
+      "category_uid": "1",
+      "class_name": "Text Completion",
+      "class_uid": "10201"
+    },
+    {
+      "category_name": "Natural Language Processing",
+      "category_uid": "1",
+      "class_name": "Problem Solving",
+      "class_uid": "10702"
+    }
+  ],
+  "locators": [
+    {
+      "type": "docker-image",
+      "url": "https://ghcr.io/agntcy/marketing-strategy"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "license",
+      "version": "v1.0.0",
+      "data": {
+        "header": "Copyright (c) 2025 Cisco and/or its affiliates.",
+        "license": "Apache-2.0"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/framework",
+      "version": "v0.0.0",
+      "data": {
+        "name": "crewai",
+        "version": "0.55.2"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/language",
+      "version": "v0.0.0",
+      "data": {
+        "type": "python",
+        "version": "\u003e=3.11,\u003c3.13"
+      }
+    }
+  ]
+}

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.base.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.base.json
@@ -10,16 +10,10 @@
   },
   "skills": [
     {
-      "category_name": "Natural Language Processing",
-      "category_uid": "1",
-      "class_name": "Text Completion",
-      "class_uid": "10201"
+      "category_name": "Text Completion [10201]"
     },
     {
-      "category_name": "Natural Language Processing",
-      "category_uid": "1",
-      "class_name": "Problem Solving",
-      "class_uid": "10702"
+      "category_name": "Problem Solving [10702]"
     }
   ],
   "locators": [

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.json
@@ -1,0 +1,57 @@
+{
+  "name": "directory.agntcy.org/cisco/marketing-strategy",
+  "version": "v1.0.0",
+  "authors": [
+    "Cisco Systems"
+  ],
+  "created_at": "2025-03-19T17:06:37Z",
+  "annotations": {
+    "key": "value"
+  },
+  "skills": [
+    {
+      "category_name": "Natural Language Processing",
+      "category_uid": "1",
+      "class_name": "Text Completion",
+      "class_uid": "10201"
+    },
+    {
+      "category_name": "Natural Language Processing",
+      "category_uid": "1",
+      "class_name": "Problem Solving",
+      "class_uid": "10702"
+    }
+  ],
+  "locators": [
+    {
+      "type": "docker-image",
+      "url": "https://ghcr.io/agntcy/marketing-strategy"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "license",
+      "version": "v1.0.0",
+      "data": {
+        "header": "Copyright (c) 2025 Cisco and/or its affiliates.",
+        "license": "Apache-2.0"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/framework",
+      "version": "v0.0.0",
+      "data": {
+        "name": "crewai",
+        "version": "0.55.2"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/language",
+      "version": "v0.0.0",
+      "data": {
+        "type": "python",
+        "version": "\u003e=3.11,\u003c3.13"
+      }
+    }
+  ]
+}

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/agent.json
@@ -10,16 +10,10 @@
   },
   "skills": [
     {
-      "category_name": "Natural Language Processing",
-      "category_uid": "1",
-      "class_name": "Text Completion",
-      "class_uid": "10201"
+      "category_name": "Text Completion [10201]"
     },
     {
-      "category_name": "Natural Language Processing",
-      "category_uid": "1",
-      "class_name": "Problem Solving",
-      "class_uid": "10702"
+      "category_name": "Problem Solving [10702]"
     }
   ],
   "locators": [

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/build.config.yml
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/build.config.yml
@@ -1,0 +1,14 @@
+builder:
+  # Base agent model path.
+  # Path is either absolute or relative to this build config file.
+  base-model: "agent.base.json"
+
+  # List of paths to ignore
+  source-ignore:
+    - ".venv/"
+
+  # Enable or disable the LLMAnalyzer plugin
+  llmanalyzer: false
+
+  # Enable or disable the runtime plugin
+  runtime: false

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/examples/crewai.agent.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/examples/crewai.agent.json
@@ -1,0 +1,125 @@
+{
+  "name": "research_crew",
+  "version": "v0.1.18",
+  "authors": [
+    "Agntcy"
+  ],
+  "annotations": {
+    "name": "research-agent",
+    "version": "v0.1.18",
+    "type": "langgraph",
+    "owner": "agntcy"
+  },
+  "created_at": "2025-03-25T12:33:14Z",
+  "skills": [
+    {
+      "category_name": "Natural Language Understanding"
+    },
+    {
+      "category_name": "Natural Language Generation"
+    },
+    {
+      "category_name": "Information Retrieval and Synthesis"
+    },
+    {
+      "category_name": "Fact Extraction"
+    },
+    {
+      "category_name": "Knowledge Synthesis"
+    }
+  ],
+  "locators": [
+    {
+      "type": "source-code",
+      "url": "https://github.com/agntcy/csit/tree/main/samples/crewai/simple_crew"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "oasf.agntcy.org/features/runtime/framework",
+      "version": "v0.0.0",
+      "data": {
+        "sbom": {
+          "name": "simple_crew",
+          "packages": [
+            {
+              "name": "crewai",
+              "version": "0.108.0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/observability/logging",
+      "version": "v1.0.0",
+      "data": {
+        "format": "\u003cstring\u003e",
+        "type": "stdout"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/observability/metrics",
+      "version": "v1.0.0",
+      "data": {
+        "task_duration": "task_duration",
+        "token_usage": [
+          "total_tokens",
+          "prompt_tokens",
+          "cached_prompt_tokens",
+          "completion_tokens",
+          "successful_requests"
+        ]
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/orchestration",
+      "version": "v1.0.0",
+      "data": {
+        "type": "sequential"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/memory",
+      "version": "v1.0.0",
+      "data": {
+        "enabled": false
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/language",
+      "version": "v0.0.0",
+      "data": {
+        "type": "python",
+        "version": "\u003c3.13,\u003e=3.10"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/io-mapper",
+      "version": "v1.0.0",
+      "data": {
+        "input_name": "topic",
+        "input_type": "string",
+        "output_description": "A fully fledge reports with the mains topics, each with a full section of information. Formatted as markdown without '```'",
+        "output_name": "report",
+        "output_type": "file"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/llm",
+      "version": "v1.0.0",
+      "data": {
+        "base_url": "http://localhost:11434",
+        "model": "ollama/llama3.1"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/evaluation",
+      "version": "v1.0.0",
+      "data": {
+        "provider": "local",
+        "type": "evaluator agent"
+      }
+    }
+  ]
+}

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/examples/langgraph.agent.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/examples/langgraph.agent.json
@@ -1,0 +1,111 @@
+{
+  "name": "research",
+  "version": "0.1.0",
+  "authors": [
+    "Agntcy"
+  ],
+  "annotations": {
+    "name": "research-agent",
+    "version": "0.1.0",
+    "type": "langgraph",
+    "owner": "agntcy"
+  },
+  "created_at": "2025-03-25T12:38:35Z",
+  "skills": [
+    {
+      "category_name": "Natural Language Understanding"
+    },
+    {
+      "category_name": "Natural Language Generation"
+    },
+    {
+      "category_name": "Information Retrieval and Synthesis"
+    },
+    {
+      "category_name": "Fact Extraction"
+    },
+    {
+      "category_name": "Knowledge Synthesis"
+    }
+  ],
+  "locators": [
+    {
+      "type": "source-code",
+      "url": "https://github.com/agntcy/csit/tree/main/samples/langgraph/research"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "oasf.agntcy.org/features/runtime/framework",
+      "version": "v0.0.0",
+      "data": {
+        "sbom": {
+          "name": "research",
+          "packages": [
+            {
+              "name": "langchain",
+              "version": "0.3.21"
+            },
+            {
+              "name": "langchain-ollama",
+              "version": "0.2.3"
+            },
+            {
+              "name": "langchain-openai",
+              "version": "0.3.10"
+            },
+            {
+              "name": "langgraph",
+              "version": "0.3.19"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/language",
+      "version": "v0.0.0",
+      "data": {
+        "type": "python",
+        "version": "\u003c4.0,\u003e=3.9"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/orchestration",
+      "version": "v1.0.0",
+      "data": {
+        "type": "graph"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/io-mapper",
+      "version": "v1.0.0",
+      "data": {
+        "input_name": "topic",
+        "input_type": "string",
+        "output_description": "Create a detailed markdown report about {state['topic']} based on these research findings: {'\n'.join(state['research_findings'])}. Expand each finding into a full section, ensuring comprehensive coverage.",
+        "output_name": "report",
+        "output_type": "string"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/observability/logging",
+      "version": "v1.0.0",
+      "data": {
+        "format": "\u003cstring\u003e",
+        "type": "stdout"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/llm",
+      "version": "v1.0.0",
+      "data": {
+        "max_retries": 2,
+        "max_tokens": null,
+        "model": "gpt-4o-mini",
+        "temperature": 0,
+        "timeout": null
+      }
+    }
+  ]
+}

--- a/integrations/agntcy-dir/examples/dir/e2e/testdata/examples/llama-index.agent.json
+++ b/integrations/agntcy-dir/examples/dir/e2e/testdata/examples/llama-index.agent.json
@@ -1,0 +1,99 @@
+{
+  "name": "research",
+  "version": "0.1.0",
+  "authors": [
+    "Agntcy"
+  ],
+  "annotations": {
+    "name": "research-agent",
+    "type": "llama-index",
+    "owner": "agntcy"
+  },
+  "created_at": "2025-03-25T12:39:29Z",
+  "skills": [
+    {
+      "category_name": "Natural Language Understanding"
+    },
+    {
+      "category_name": "Natural Language Generation"
+    },
+    {
+      "category_name": "Information Retrieval and Synthesis"
+    },
+    {
+      "category_name": "Fact Extraction"
+    },
+    {
+      "category_name": "Knowledge Synthesis"
+    }
+  ],
+  "locators": [
+    {
+      "type": "source-code",
+      "url": "https://github.com/agntcy/csit/tree/main/samples/llama-index/research"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "oasf.agntcy.org/features/framework/llm",
+      "version": "v1.0.0",
+      "data": {
+        "model": "gpt-4o-mini",
+        "temperature": 0.5
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/framework/orchestration",
+      "version": "v1.0.0",
+      "data": {
+        "type": "workflow"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/io-mapper",
+      "version": "v1.0.0",
+      "data": {
+        "input_name": "topic",
+        "input_type": "string",
+        "output_description": "Create a detailed markdown report about {topic} based on these research findings: {research}. Expand each finding into a full section, ensuring comprehensive coverage.",
+        "output_name": "report",
+        "output_type": "string"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/observability/logging",
+      "version": "v1.0.0",
+      "data": {
+        "format": "\u003cstring\u003e",
+        "type": "stdout"
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/framework",
+      "version": "v0.0.0",
+      "data": {
+        "sbom": {
+          "name": "research",
+          "packages": [
+            {
+              "name": "llama-index",
+              "version": "0.12.25"
+            },
+            {
+              "name": "llama-index-llms-azure-openai",
+              "version": "0.3.2"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "oasf.agntcy.org/features/runtime/language",
+      "version": "v0.0.0",
+      "data": {
+        "type": "python",
+        "version": "\u003c4.0,\u003e=3.9"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR removes agntcy/dir as a submodule, and add the directory using read-tree instead.

If we want to update the `integrations/agntcy-dir/examples/dir/e2e/testdata` directory we will need to add agntcy/dir as a remote and create a patch for it by diffing with the `agntcy/dir` repo

```
# add agntcy/dir as remote
git remote add -f dir https://github.com/agntcy/dir.git
# fetch dir
git fetch dir
# example of updating the integrations/agntcy-dir/examples/dir/e2e/testdata directory to the agntcy/dir main
git diff --binary HEAD:integrations/agntcy-dir/examples/dir/e2e/testdata dir/main:e2e/testdata | git apply --directory=integrations/agntcy-dir/examples/dir/e2e/testdata
 ```