### PR TITLE
fix: sometimes sanity test is failing due to wrong order of container initialization

### DIFF
--- a/integrations/agntcy-slim/tests/sanity_test.go
+++ b/integrations/agntcy-slim/tests/sanity_test.go
@@ -118,7 +118,6 @@ var _ = ginkgo.Describe("Agntcy slim sanity test", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to delete pod")
 			})
 
-			// Wait for pod to be running
 			err = k8sHelper.WaitForPodRunning(k8sTimeOutSeconds * time.Second)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), createdPod)
 		})

--- a/integrations/testutils/k8shelper/job.go
+++ b/integrations/testutils/k8shelper/job.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (k *k8sHelper) CreateJob() (*batchv1.Job, error) {
-	var backOffLimit int32 = 2
+	var backOffLimit int32 = 3
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k.name,
@@ -29,7 +29,7 @@ func (k *k8sHelper) CreateJob() (*batchv1.Job, error) {
 							Image: k.imageName,
 						},
 					},
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy: corev1.RestartPolicyOnFailure,
 				},
 			},
 			BackoffLimit: &backOffLimit,

--- a/integrations/testutils/k8shelper/spire_helper.go
+++ b/integrations/testutils/k8shelper/spire_helper.go
@@ -49,11 +49,6 @@ func (k *k8sHelper) WithSpireHelper() *k8sHelper {
 			Name:  "spiffe-helper",
 			Image: "ghcr.io/spiffe/spiffe-helper:0.10.0",
 			Args:  []string{"-config", "config/helper.conf"},
-			// Use inline func to get address of the constant
-			RestartPolicy: func() *corev1.ContainerRestartPolicy {
-				v := corev1.ContainerRestartPolicyAlways
-				return &v
-			}(),
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "config-volume",


### PR DESCRIPTION
- remove always restart from initcontainer
- increase backoff limit for lang-chain job 
- set restart policy to restart on failure.