### PR TITLE
test(a2a): add scenario parity coverage

### DIFF
--- a/integrations/agntcy-a2a/README.md
+++ b/integrations/agntcy-a2a/README.md
@@ -8,12 +8,19 @@ All 12 Rust/Go client-server legs in the current core lifecycle matrix are green
 
 The Go and Rust fixtures now expose push-config CRUD. CSIT validates that path from both clients against both server targets across JSON-RPC, HTTP+JSON, and gRPC.
 
-The Rust/.NET slice now exists alongside the Rust/Go suite. It reuses the existing Rust fixture and Rust probe, adds CSIT-owned .NET fixture and probe binaries, and runs exactly 8 specs: 4 JSON-RPC legs (`dotnet-dotnet`, `dotnet-rust`, `rust-dotnet`, `rust-rust-dotnet`) plus the same 4 legs over HTTP+JSON. Each of those specs exercises unary and streaming `SendMessage`, `GetTask`, `ListTasks`, `CancelTask`, the missing-task and non-cancelable-task error paths, and preservation of mixed text plus structured-data content through task history. Push-config is covered in this slice as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. This slice does not cover gRPC. The default `task test` and `task integrations:a2a:test` entrypoints now run both the established Rust/Go matrix and this Rust/.NET slice.
+The Rust/.NET slice now exists alongside the Rust/Go suite. It reuses the existing Rust fixture and Rust probe, adds CSIT-owned .NET fixture and probe binaries, and runs exactly 8 specs: 4 JSON-RPC legs (`dotnet-dotnet`, `dotnet-rust`, `rust-dotnet`, `rust-rust-dotnet`) plus the same 4 legs over HTTP+JSON. Each of those specs now exercises the original lifecycle slice plus the richer scenario-parity slice: message-only responses, failed tasks, multi-turn input-required continuations, long-running completions, artifact-rich streaming updates, structured text/data/URL artifacts, extended-agent-card discovery, and preservation of mixed text plus structured-data content through task history. Push-config is covered in this slice as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. This slice does not cover gRPC. The default `task test` and `task integrations:a2a:test` entrypoints now run both the established Rust/Go matrix and this Rust/.NET slice.
 
 Across the matrix, the scenarios validate the same core interoperability behavior:
 
 - unary and streaming `SendMessage`
+- message-only responses without task creation
 - lifecycle methods across `GetTask`, `ListTasks`, and `CancelTask`
+- failed-task responses
+- multi-turn `TASK_STATE_INPUT_REQUIRED` continuations
+- long-running completion after non-blocking sends
+- artifact-rich streaming updates
+- structured text + data + URL artifact payloads
+- extended-agent-card discovery and skill metadata
 - negative-path error semantics for missing and non-cancelable tasks
 - successful push-config CRUD on both server paths across all three transports
 - preservation of a mixed text plus structured-data request payload and message metadata through task history
@@ -61,13 +68,23 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | --- | --- | --- |
 | Unary `SendMessage` | ✅ | ✅ |
 | Streaming `SendMessage` | ✅ | ✅ |
+| Message-only response path | ✅ | ✅ |
 | `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ |
+| Failed-task response path | ✅ | ✅ |
+| Multi-turn input-required continuation | ✅ | ✅ |
+| Long-running completion after non-blocking send | ✅ | ✅ |
+| Artifact-rich streaming updates | ✅ | ✅ |
+| Structured text + data + URL artifact payloads | ✅ | ✅ |
+| Extended-agent-card discovery | ✅ | ✅ |
+| Extended-card security-scheme metadata | ✅ | ✅ |
 | Missing-task and non-cancelable-task errors | ✅ | ✅ |
 | Mixed text + structured-data payload preserved through task history | ✅ | ✅ |
 | Push-config CRUD against Rust-server targets | ✅ | ✅ |
 | Unsupported push-config response against non-Rust server targets | ✅ | ✅ |
 
 For Rust/.NET, the uncovered cells are the current gRPC gap. For push-config, a ✅ means the suite verifies the expected behavior for that leg: CRUD succeeds on Rust-server targets and the current unsupported error is returned on Go-server or .NET-server targets.
+
+For the .NET-owned fixture specifically, the public and extended cards currently omit `securitySchemes` because the released Rust resolver used by this CSIT slice does not yet accept the .NET SDK's null-filled union encoding for that field. The overall suites still validate bearer-token security metadata against the Rust and Go fixtures.
 
 ## Running the Suite
 

--- a/integrations/agntcy-a2a/fixtures/dotnet/InteropProbe/Program.cs
+++ b/integrations/agntcy-a2a/fixtures/dotnet/InteropProbe/Program.cs
@@ -16,10 +16,29 @@ internal static class Program
 {
     private const string RequestText = "ping";
     private const string PendingRequestText = "pending";
+    private const string MessageOnlyRequestText = "message-only";
+    private const string TaskFailureRequestText = "task-failure";
+    private const string MultiTurnStartRequestText = "multi-turn start";
+    private const string MultiTurnContinueRequestText = "multi-turn continue";
+    private const string StreamingRequestText = "streaming";
+    private const string LongRunningRequestText = "long-running";
+    private const string DataTypesRequestText = "data-types";
     private const string RequestDataKind = "structured";
     private const string RequestDataScope = "interop";
     private const string RequestMetadataKey = "csit";
     private const string RequestMetadataValue = "multipart";
+    private const string ExtendedCardSchemeId = "bearer_token";
+    private static readonly string[] ExpectedSkillIds =
+    [
+        "message-only",
+        "task-lifecycle",
+        "task-failure",
+        "task-cancel",
+        "multi-turn",
+        "streaming",
+        "long-running",
+        "data-types",
+    ];
 
     public static async Task<int> Main(string[] args)
     {
@@ -56,6 +75,15 @@ internal static class Program
         var expectedPingText = ExpectedResponseText(options.ServerPrefix, RequestText);
         var expectedPendingText = ExpectedResponseText(options.ServerPrefix, PendingRequestText);
         var expectedCancelText = ExpectedCancelText(options.ServerPrefix);
+        var expectedMessageOnlyText = ExpectedScenarioText(options.ServerPrefix, "message-only response");
+        var expectedFailedText = ExpectedScenarioText(options.ServerPrefix, "failed task");
+        var expectedInputRequiredText = ExpectedScenarioText(options.ServerPrefix, "needs more input");
+        var expectedMultiTurnCompleteText = ExpectedScenarioText(options.ServerPrefix, "multi-turn completed");
+        var expectedStreamingStartText = ExpectedScenarioText(options.ServerPrefix, "streaming started");
+        var expectedStreamingCompleteText = ExpectedScenarioText(options.ServerPrefix, "streaming complete");
+        var expectedLongRunningStartText = ExpectedScenarioText(options.ServerPrefix, "long-running started");
+        var expectedLongRunningCompleteText = ExpectedScenarioText(options.ServerPrefix, "long-running complete");
+        var expectedDataTypesText = ExpectedScenarioText(options.ServerPrefix, "data-types ready");
 
         var request = BuildRequest(RequestText, false);
 
@@ -228,11 +256,109 @@ internal static class Program
             }
         }
 
+        var messageOnly = MessageFromResponse(
+            await SendMessageAsync(client, card, BuildRequest(MessageOnlyRequestText, false), false).ConfigureAwait(false),
+            "message-only");
+        AssertText(FirstText(messageOnly), expectedMessageOnlyText, "message-only");
+
+        var failedTask = TaskFromResponse(
+            await SendMessageAsync(client, card, BuildRequest(TaskFailureRequestText, false), false).ConfigureAwait(false),
+            "task-failure");
+        AssertState(failedTask.Status.State, TaskState.Failed, "task-failure");
+        AssertText(TaskText(failedTask), expectedFailedText, "task-failure");
+
+        var inputRequiredTask = TaskFromResponse(
+            await SendMessageAsync(client, card, BuildRequest(MultiTurnStartRequestText, false), false).ConfigureAwait(false),
+            "multi-turn start");
+        AssertState(inputRequiredTask.Status.State, TaskState.InputRequired, "multi-turn start");
+        AssertText(TaskText(inputRequiredTask), expectedInputRequiredText, "multi-turn start");
+        AssertTaskHistory(inputRequiredTask, MultiTurnStartRequestText, "multi-turn start");
+
+        var multiTurnCompleted = TaskFromResponse(
+            await SendMessageAsync(
+                client,
+                card,
+                BuildRequest(MultiTurnContinueRequestText, false, inputRequiredTask.Id, inputRequiredTask.ContextId),
+                false).ConfigureAwait(false),
+            "multi-turn continuation");
+        AssertState(multiTurnCompleted.Status.State, TaskState.Completed, "multi-turn continuation");
+        AssertText(TaskText(multiTurnCompleted), expectedMultiTurnCompleteText, "multi-turn continuation");
+        AssertTaskHistoryEntries(multiTurnCompleted, [MultiTurnStartRequestText, MultiTurnContinueRequestText], "multi-turn continuation");
+
+        var sawStreamingStart = false;
+        var sawStreamingComplete = false;
+        var sawAppend = false;
+        var streamingChunks = new List<string>();
+        await foreach (var response in SendStreamingMessageAsync(client, card, BuildRequest(StreamingRequestText, false)).ConfigureAwait(false))
+        {
+            switch (response.PayloadCase)
+            {
+                case StreamResponseCase.Task:
+                    sawStreamingStart = true;
+                    AssertState(response.Task!.Status.State, TaskState.Working, "streaming scenario task");
+                    AssertText(TaskText(response.Task), expectedStreamingStartText, "streaming scenario task");
+                    break;
+                case StreamResponseCase.ArtifactUpdate:
+                    streamingChunks.Add(FirstArtifactText(response.ArtifactUpdate!.Artifact));
+                    if (response.ArtifactUpdate.Append)
+                    {
+                        sawAppend = true;
+                    }
+                    break;
+                case StreamResponseCase.StatusUpdate:
+                    sawStreamingComplete = true;
+                    AssertState(response.StatusUpdate!.Status.State, TaskState.Completed, "streaming scenario status");
+                    AssertText(FirstText(response.StatusUpdate.Status.Message!), expectedStreamingCompleteText, "streaming scenario status");
+                    break;
+                case StreamResponseCase.Message:
+                    throw new InvalidOperationException("streaming scenario yielded an unexpected message event");
+                default:
+                    throw new InvalidOperationException($"unexpected streaming scenario payload case {response.PayloadCase}");
+            }
+        }
+        if (!sawStreamingStart || !sawStreamingComplete)
+        {
+            throw new InvalidOperationException("streaming scenario did not emit the expected task/status events");
+        }
+        if (streamingChunks.Count != 2 || streamingChunks[0] != "streaming chunk 1" || streamingChunks[1] != "streaming chunk 2")
+        {
+            throw new InvalidOperationException($"streaming scenario artifact chunks mismatch: got [{string.Join(", ", streamingChunks)}]");
+        }
+        if (!sawAppend)
+        {
+            throw new InvalidOperationException("streaming scenario did not emit an append artifact update");
+        }
+
+        var longRunningTask = TaskFromResponse(
+            await SendMessageAsync(client, card, BuildRequest(LongRunningRequestText, true), true).ConfigureAwait(false),
+            "long-running");
+        var longRunningCompleted = longRunningTask.Status.State switch
+        {
+            TaskState.Working => await WaitForTaskStateAsync(client, card, longRunningTask.Id, TaskState.Completed, "long-running").ConfigureAwait(false),
+            TaskState.Completed => longRunningTask,
+            _ => throw new InvalidOperationException($"unexpected long-running task state: got {longRunningTask.Status.State}, want Working or Completed"),
+        };
+        if (longRunningTask.Status.State == TaskState.Working)
+        {
+            AssertText(TaskText(longRunningTask), expectedLongRunningStartText, "long-running");
+        }
+        AssertText(TaskText(longRunningCompleted), expectedLongRunningCompleteText, "long-running completion");
+
+        var dataTypesTask = TaskFromResponse(
+            await SendMessageAsync(client, card, BuildRequest(DataTypesRequestText, false), false).ConfigureAwait(false),
+            "data-types");
+        AssertState(dataTypesTask.Status.State, TaskState.Completed, "data-types");
+        AssertText(TaskText(dataTypesTask), expectedDataTypesText, "data-types");
+        AssertDataTypesTask(dataTypesTask, "data-types");
+
+        var extendedCard = await GetExtendedAgentCardAsync(client, card).ConfigureAwait(false);
+        AssertExtendedCardMetadata(extendedCard, "extended-card");
+
         var protocol = card.SupportedInterfaces.FirstOrDefault()?.ProtocolBinding ?? "unknown";
         Console.WriteLine($"validated {options.ServerPrefix} {protocol} lifecycle against {options.CardUrl}");
     }
 
-    private static SendMessageRequest BuildRequest(string text, bool returnImmediately)
+    private static SendMessageRequest BuildRequest(string text, bool returnImmediately, string? taskId = null, string? contextId = null)
     {
         return new SendMessageRequest
         {
@@ -240,6 +366,8 @@ internal static class Program
             {
                 Role = Role.User,
                 MessageId = Guid.NewGuid().ToString("N"),
+                TaskId = taskId,
+                ContextId = contextId,
                 Parts =
                 [
                     Part.FromText(text),
@@ -409,6 +537,16 @@ internal static class Program
         }
 
         throw new InvalidOperationException($"agent card did not advertise a supported interface: {agentInterface.ProtocolBinding}");
+    }
+
+    private static async Task<AgentCard> GetExtendedAgentCardAsync(IA2AClient? client, AgentCard card)
+    {
+        if (UsesJsonRpcCompat(card))
+        {
+            return await client!.GetExtendedAgentCardAsync(new GetExtendedAgentCardRequest()).ConfigureAwait(false);
+        }
+
+        return await GetRestAsync<AgentCard>(card, "/extendedAgentCard").ConfigureAwait(false);
     }
 
     private static CompatibleTaskPushNotificationConfig ToCompatibleTaskPushNotificationConfig(TaskPushNotificationConfig config)
@@ -873,9 +1011,17 @@ internal static class Program
     private static string ExpectedCancelText(string serverPrefix) =>
         $"{serverPrefix} server canceled task";
 
+    private static string ExpectedScenarioText(string serverPrefix, string suffix) =>
+        $"{serverPrefix} server {suffix}";
+
     private static AgentTask TaskFromResponse(SendMessageResponse response, string kind)
     {
         return response.Task ?? throw new InvalidOperationException($"unexpected {kind} response type: Message");
+    }
+
+    private static Message MessageFromResponse(SendMessageResponse response, string kind)
+    {
+        return response.Message ?? throw new InvalidOperationException($"unexpected {kind} response type: Task");
     }
 
     private static string TaskText(AgentTask task)
@@ -909,14 +1055,25 @@ internal static class Program
 
     private static void AssertTaskHistory(AgentTask task, string expectedText, string kind)
     {
-        if (task.History is null || task.History.Count != 1)
+        AssertTaskHistoryEntries(task, [expectedText], kind);
+    }
+
+    private static void AssertTaskHistoryEntries(AgentTask task, IReadOnlyList<string> expectedTexts, string kind)
+    {
+        if (task.History is null || task.History.Count != expectedTexts.Count)
         {
-            throw new InvalidOperationException($"{kind} task did not include a single history entry");
+            throw new InvalidOperationException($"{kind} task history length mismatch: got {task.History?.Count ?? 0}, want {expectedTexts.Count}");
         }
 
-        var message = task.History[0];
-        AssertText(FirstText(message), expectedText, kind);
+        foreach (var (message, expectedText) in task.History.Zip(expectedTexts))
+        {
+            AssertMessagePayload(message, expectedText, kind);
+        }
+    }
 
+    private static void AssertMessagePayload(Message message, string expectedText, string kind)
+    {
+        AssertText(FirstText(message), expectedText, kind);
         if (message.Parts.Count != 2)
         {
             throw new InvalidOperationException($"{kind} task history had {message.Parts.Count} parts, want 2");
@@ -938,6 +1095,101 @@ internal static class Program
         if (!string.Equals(metadataValue.GetString(), RequestMetadataValue, StringComparison.Ordinal))
         {
             throw new InvalidOperationException($"{kind} task history metadata mismatch: got '{metadataValue.GetString()}', want '{RequestMetadataValue}'");
+        }
+    }
+
+    private static async Task<AgentTask> WaitForTaskStateAsync(IA2AClient? client, AgentCard card, string taskId, TaskState expectedState, string kind)
+    {
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            var task = await GetTaskAsync(client, card, new GetTaskRequest { Id = taskId }).ConfigureAwait(false);
+            if (task.Status.State == expectedState)
+            {
+                return task;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException($"timed out waiting for {kind} to reach state {expectedState}");
+    }
+
+    private static string FirstArtifactText(Artifact artifact)
+    {
+        var part = artifact.Parts.FirstOrDefault(value => value.Text is not null);
+        return part?.Text ?? throw new InvalidOperationException("artifact contained no text parts");
+    }
+
+    private static void AssertDataTypesTask(AgentTask task, string kind)
+    {
+        if (task.Artifacts is null || task.Artifacts.Count != 1)
+        {
+            throw new InvalidOperationException($"{kind} task artifact count mismatch: got {task.Artifacts?.Count ?? 0}, want 1");
+        }
+
+        var artifact = task.Artifacts[0];
+        if (artifact.Parts.Count != 3)
+        {
+            throw new InvalidOperationException($"{kind} artifact part count mismatch: got {artifact.Parts.Count}, want 3");
+        }
+
+        AssertText(artifact.Parts[0].Text ?? string.Empty, "structured summary", kind);
+
+        var data = artifact.Parts[1].Data
+            ?? throw new InvalidOperationException($"{kind} data-types artifact second part was not data");
+        var items = data.GetProperty("items");
+        var itemsMatches = (items.TryGetInt32(out var itemsInt) && itemsInt == 2)
+            || (items.TryGetInt64(out var itemsLong) && itemsLong == 2)
+            || (items.TryGetDouble(out var itemsDouble) && Math.Abs(itemsDouble - 2.0) < double.Epsilon);
+        if (data.ValueKind != JsonValueKind.Object
+            || data.GetProperty("kind").GetString() != "report"
+            || !itemsMatches)
+        {
+            throw new InvalidOperationException($"{kind} data-types artifact data payload mismatch");
+        }
+
+        if (!string.Equals(artifact.Parts[2].Url, "https://example.invalid/diagram.svg", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"{kind} data-types artifact URL mismatch");
+        }
+        if (!string.Equals(artifact.Parts[2].MediaType, "image/svg+xml", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"{kind} data-types artifact media type mismatch");
+        }
+        if (!string.Equals(artifact.Parts[2].Filename, "diagram.svg", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"{kind} data-types artifact filename mismatch");
+        }
+    }
+
+    private static void AssertExtendedCardMetadata(AgentCard card, string kind)
+    {
+        if (card.Capabilities.ExtendedAgentCard != true)
+        {
+            throw new InvalidOperationException($"{kind} card did not advertise extendedAgentCard support");
+        }
+        if (!card.Description.Contains("(extended)", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"{kind} card did not include extended description metadata");
+        }
+        if (card.SecuritySchemes is not null && card.SecuritySchemes.Count > 0)
+        {
+            if (!card.SecuritySchemes.TryGetValue(ExtendedCardSchemeId, out var securityScheme))
+            {
+                throw new InvalidOperationException($"{kind} card did not include {ExtendedCardSchemeId}");
+            }
+            if (securityScheme.HttpAuthSecurityScheme?.Scheme is not "Bearer")
+            {
+                throw new InvalidOperationException($"{kind} card bearer scheme mismatch");
+            }
+        }
+
+        foreach (var expectedSkill in ExpectedSkillIds)
+        {
+            if (!card.Skills.Any(skill => string.Equals(skill.Id, expectedSkill, StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException($"{kind} card was missing skill {expectedSkill}");
+            }
         }
     }
 

--- a/integrations/agntcy-a2a/fixtures/dotnet/InteropServer/Program.cs
+++ b/integrations/agntcy-a2a/fixtures/dotnet/InteropServer/Program.cs
@@ -86,10 +86,13 @@ internal static class Program
         var builder = WebApplication.CreateBuilder(args);
         builder.WebHost.UseUrls(baseUrl);
 
-        var agentCard = InteropAgent.BuildAgentCard(baseUrl, options.Protocol);
+        var agentCard = InteropAgent.BuildAgentCard(baseUrl, options.Protocol, extended: false);
         builder.Services.AddA2AAgent<InteropAgent>(agentCard);
 
         var app = builder.Build();
+        var requestHandler = new ExtendedCardRequestHandler(
+            app.Services.GetRequiredService<IA2ARequestHandler>(),
+            InteropAgent.BuildAgentCard(baseUrl, options.Protocol, extended: true));
         if (UsesJsonRpc(options.Protocol))
         {
             app.Use(async (context, next) =>
@@ -124,17 +127,17 @@ internal static class Program
 
         if (UsesJsonRpc(options.Protocol))
         {
-            app.MapA2A("/rpc");
+            app.MapA2A(requestHandler, "/rpc");
         }
         else
         {
-            var requestHandler = app.Services.GetRequiredService<IA2ARequestHandler>();
-
             app.MapGet("/rest/card", () => Results.Ok(agentCard));
             app.MapPost("/rest/message:send", (SendMessageRequest request, CancellationToken ct) =>
                 HandleRestAsync(() => requestHandler.SendMessageAsync(request, ct)));
             app.MapPost("/rest/message:stream", (HttpContext context, SendMessageRequest request, CancellationToken ct) =>
                 StreamRestAsync(context, requestHandler.SendStreamingMessageAsync(request, ct), ct));
+            app.MapGet("/rest/extendedAgentCard", (CancellationToken ct) =>
+                HandleRestAsync(() => requestHandler.GetExtendedAgentCardAsync(new GetExtendedAgentCardRequest(), ct)));
             app.MapGet("/rest/tasks/{id}", (string id, int? historyLength, CancellationToken ct) =>
                 HandleRestAsync(() => requestHandler.GetTaskAsync(new GetTaskRequest
                 {
@@ -319,28 +322,54 @@ internal static class Program
 internal sealed class InteropAgent : IAgentHandler
 {
     private const string PendingRequestText = "pending";
+    private const string MessageOnlyRequestText = "message-only";
+    private const string TaskFailureRequestText = "task-failure";
+    private const string MultiTurnStartRequestText = "multi-turn start";
+    private const string MultiTurnContinueRequestText = "multi-turn continue";
+    private const string StreamingRequestText = "streaming";
+    private const string LongRunningRequestText = "long-running";
+    private const string DataTypesRequestText = "data-types";
 
-    public Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
-        var responseText = $"dotnet server received: {context.UserText ?? string.Empty}";
-        var state = string.Equals(context.UserText, PendingRequestText, StringComparison.Ordinal)
-            ? TaskState.Working
-            : TaskState.Completed;
-
-        var task = new AgentTask
+        switch (context.UserText)
         {
-            Id = context.TaskId,
-            ContextId = context.ContextId,
-            History = [context.Message],
-            Status = new AgentTaskStatus
-            {
-                State = state,
-                Timestamp = DateTimeOffset.UtcNow,
-                Message = BuildStatusMessage(context, responseText),
-            },
-        };
-
-        return eventQueue.EnqueueTaskAsync(task, cancellationToken).AsTask();
+            case MessageOnlyRequestText:
+                await eventQueue.EnqueueMessageAsync(BuildMessage(context, "dotnet server message-only response"), cancellationToken).ConfigureAwait(false);
+                return;
+            case TaskFailureRequestText:
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, TaskState.Failed, "dotnet server failed task"), cancellationToken).ConfigureAwait(false);
+                return;
+            case MultiTurnStartRequestText:
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, TaskState.InputRequired, "dotnet server needs more input"), cancellationToken).ConfigureAwait(false);
+                return;
+            case MultiTurnContinueRequestText:
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, TaskState.Completed, "dotnet server multi-turn completed"), cancellationToken).ConfigureAwait(false);
+                return;
+            case StreamingRequestText:
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, TaskState.Working, "dotnet server streaming started"), cancellationToken).ConfigureAwait(false);
+                await eventQueue.EnqueueArtifactUpdateAsync(BuildArtifactUpdate(context, "streaming-artifact", [Part.FromText("streaming chunk 1")]), cancellationToken).ConfigureAwait(false);
+                await eventQueue.EnqueueArtifactUpdateAsync(BuildArtifactUpdate(context, "streaming-artifact", [Part.FromText("streaming chunk 2")], append: true, lastChunk: true), cancellationToken).ConfigureAwait(false);
+                await eventQueue.EnqueueStatusUpdateAsync(BuildStatusUpdate(context, TaskState.Completed, "dotnet server streaming complete"), cancellationToken).ConfigureAwait(false);
+                return;
+            case LongRunningRequestText:
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, TaskState.Working, "dotnet server long-running started"), cancellationToken).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromMilliseconds(150), cancellationToken).ConfigureAwait(false);
+                await eventQueue.EnqueueStatusUpdateAsync(BuildStatusUpdate(context, TaskState.Working, "dotnet server long-running progress"), cancellationToken).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromMilliseconds(150), cancellationToken).ConfigureAwait(false);
+                await eventQueue.EnqueueStatusUpdateAsync(BuildStatusUpdate(context, TaskState.Completed, "dotnet server long-running complete"), cancellationToken).ConfigureAwait(false);
+                return;
+            case DataTypesRequestText:
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, TaskState.Completed, "dotnet server data-types ready", [BuildDataTypesArtifact()]), cancellationToken).ConfigureAwait(false);
+                return;
+            default:
+                var responseText = $"dotnet server received: {context.UserText ?? string.Empty}";
+                var state = string.Equals(context.UserText, PendingRequestText, StringComparison.Ordinal)
+                    ? TaskState.Working
+                    : TaskState.Completed;
+                await eventQueue.EnqueueTaskAsync(BuildTask(context, state, responseText), cancellationToken).ConfigureAwait(false);
+                return;
+        }
     }
 
     public Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
@@ -353,21 +382,23 @@ internal sealed class InteropAgent : IAgentHandler
             {
                 State = TaskState.Canceled,
                 Timestamp = DateTimeOffset.UtcNow,
-                Message = BuildStatusMessage(context, "dotnet server canceled task"),
+                Message = BuildMessage(context, "dotnet server canceled task"),
             },
         };
 
         return eventQueue.EnqueueStatusUpdateAsync(update, cancellationToken).AsTask();
     }
 
-    public static AgentCard BuildAgentCard(string baseUrl, string protocol)
+    public static AgentCard BuildAgentCard(string baseUrl, string protocol, bool extended)
     {
         var usesRest = string.Equals(protocol, "rest", StringComparison.OrdinalIgnoreCase);
 
         return new AgentCard
         {
             Name = usesRest ? "CSIT DotNet HTTP+JSON Agent" : "CSIT DotNet JSON-RPC Agent",
-            Description = "DotNet interoperability fixture for CSIT",
+            Description = extended
+                ? "DotNet interoperability fixture for CSIT (extended)"
+                : "DotNet interoperability fixture for CSIT",
             Version = "1.0.0-preview",
             SupportedInterfaces =
             [
@@ -382,14 +413,103 @@ internal sealed class InteropAgent : IAgentHandler
             {
                 Streaming = true,
                 PushNotifications = false,
+                ExtendedAgentCard = true,
             },
             DefaultInputModes = ["text/plain"],
             DefaultOutputModes = ["text/plain"],
-            Skills = [],
+            Skills =
+            [
+                BuildSkill("message-only", "Returns a message response without creating a task."),
+                BuildSkill("task-lifecycle", "Creates, lists, fetches, and cancels tasks."),
+                BuildSkill("task-failure", "Returns a failed task response."),
+                BuildSkill("task-cancel", "Creates a cancelable working task."),
+                BuildSkill("multi-turn", "Requests more input before completing the task."),
+                BuildSkill("streaming", "Streams task and artifact updates."),
+                BuildSkill("long-running", "Returns early and completes asynchronously."),
+                BuildSkill("data-types", "Produces text, structured data, and URL parts."),
+            ],
         };
     }
 
-    private static Message BuildStatusMessage(RequestContext context, string text) =>
+    private static AgentSkill BuildSkill(string id, string description) =>
+        new()
+        {
+            Id = id,
+            Name = id,
+            Description = description,
+            Tags = ["csit", "scenario-parity"],
+        };
+
+    private static List<Message> BuildHistory(RequestContext context)
+    {
+        var history = context.Task?.History is { Count: > 0 }
+            ? [.. context.Task.History]
+            : new List<Message>();
+        if (history.Count == 0 || !string.Equals(history[^1].MessageId, context.Message.MessageId, StringComparison.Ordinal))
+        {
+            history.Add(context.Message);
+        }
+        return history;
+    }
+
+    private static AgentTask BuildTask(RequestContext context, TaskState state, string text, List<Artifact>? artifacts = null) =>
+        new()
+        {
+            Id = context.TaskId,
+            ContextId = context.ContextId,
+            History = BuildHistory(context),
+            Artifacts = artifacts,
+            Status = new AgentTaskStatus
+            {
+                State = state,
+                Timestamp = DateTimeOffset.UtcNow,
+                Message = BuildMessage(context, text),
+            },
+        };
+
+    private static TaskStatusUpdateEvent BuildStatusUpdate(RequestContext context, TaskState state, string text) =>
+        new()
+        {
+            TaskId = context.TaskId,
+            ContextId = context.ContextId,
+            Status = new AgentTaskStatus
+            {
+                State = state,
+                Timestamp = DateTimeOffset.UtcNow,
+                Message = BuildMessage(context, text),
+            },
+        };
+
+    private static TaskArtifactUpdateEvent BuildArtifactUpdate(RequestContext context, string artifactId, List<Part> parts, bool append = false, bool lastChunk = false) =>
+        new()
+        {
+            TaskId = context.TaskId,
+            ContextId = context.ContextId,
+            Append = append,
+            LastChunk = lastChunk,
+            Artifact = new Artifact
+            {
+                ArtifactId = artifactId,
+                Name = artifactId,
+                Parts = parts,
+            },
+        };
+
+    private static Artifact BuildDataTypesArtifact() =>
+        new()
+        {
+            ArtifactId = Guid.NewGuid().ToString("N"),
+            Name = "data-types-artifact",
+            Description = "Mixed content artifact for scenario parity",
+            Parts =
+            [
+                Part.FromText("structured summary"),
+                Part.FromData(JsonSerializer.SerializeToElement(new { kind = "report", items = 2 })),
+                Part.FromUrl("https://example.invalid/diagram.svg", "image/svg+xml", "diagram.svg"),
+            ],
+        };
+
+    private static Message BuildMessage(RequestContext context, string text) =>
         new()
         {
             Role = Role.Agent,
@@ -398,6 +518,51 @@ internal sealed class InteropAgent : IAgentHandler
             TaskId = context.TaskId,
             Parts = [Part.FromText(text)],
         };
+}
+
+internal sealed class ExtendedCardRequestHandler : IA2ARequestHandler
+{
+    private readonly IA2ARequestHandler _inner;
+    private readonly AgentCard _extendedCard;
+
+    public ExtendedCardRequestHandler(IA2ARequestHandler inner, AgentCard extendedCard)
+    {
+        _inner = inner;
+        _extendedCard = extendedCard;
+    }
+
+    public Task<SendMessageResponse> SendMessageAsync(SendMessageRequest request, CancellationToken cancellationToken = default) =>
+        _inner.SendMessageAsync(request, cancellationToken);
+
+    public IAsyncEnumerable<StreamResponse> SendStreamingMessageAsync(SendMessageRequest request, CancellationToken cancellationToken = default) =>
+        _inner.SendStreamingMessageAsync(request, cancellationToken);
+
+    public Task<AgentTask> GetTaskAsync(GetTaskRequest request, CancellationToken cancellationToken = default) =>
+        _inner.GetTaskAsync(request, cancellationToken);
+
+    public Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request, CancellationToken cancellationToken = default) =>
+        _inner.ListTasksAsync(request, cancellationToken);
+
+    public Task<AgentTask> CancelTaskAsync(CancelTaskRequest request, CancellationToken cancellationToken = default) =>
+        _inner.CancelTaskAsync(request, cancellationToken);
+
+    public IAsyncEnumerable<StreamResponse> SubscribeToTaskAsync(SubscribeToTaskRequest request, CancellationToken cancellationToken = default) =>
+        _inner.SubscribeToTaskAsync(request, cancellationToken);
+
+    public Task<TaskPushNotificationConfig> CreateTaskPushNotificationConfigAsync(CreateTaskPushNotificationConfigRequest request, CancellationToken cancellationToken = default) =>
+        _inner.CreateTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task<ListTaskPushNotificationConfigResponse> ListTaskPushNotificationConfigAsync(ListTaskPushNotificationConfigRequest request, CancellationToken cancellationToken = default) =>
+        _inner.ListTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task<TaskPushNotificationConfig> GetTaskPushNotificationConfigAsync(GetTaskPushNotificationConfigRequest request, CancellationToken cancellationToken = default) =>
+        _inner.GetTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task DeleteTaskPushNotificationConfigAsync(DeleteTaskPushNotificationConfigRequest request, CancellationToken cancellationToken = default) =>
+        _inner.DeleteTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task<AgentCard> GetExtendedAgentCardAsync(GetExtendedAgentCardRequest request, CancellationToken cancellationToken = default) =>
+        Task.FromResult(_extendedCard);
 }
 
 internal sealed class ServerOptions

--- a/integrations/agntcy-a2a/fixtures/go-jsonrpc-server/main.go
+++ b/integrations/agntcy-a2a/fixtures/go-jsonrpc-server/main.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
@@ -27,10 +28,18 @@ import (
 type transportProtocol string
 
 const (
-	pendingRequestText                         = "pending"
-	transportProtocolJSONRPC transportProtocol = "jsonrpc"
-	transportProtocolREST    transportProtocol = "rest"
-	transportProtocolGRPC    transportProtocol = "grpc"
+	pendingRequestText                             = "pending"
+	messageOnlyRequestText                         = "message-only"
+	taskFailureRequestText                         = "task-failure"
+	multiTurnStartRequestText                      = "multi-turn start"
+	multiTurnContinueRequestText                   = "multi-turn continue"
+	streamingRequestText                           = "streaming"
+	longRunningRequestText                         = "long-running"
+	dataTypesRequestText                           = "data-types"
+	extendedCardSchemeID                           = a2a.SecuritySchemeName("bearer_token")
+	transportProtocolJSONRPC     transportProtocol = "jsonrpc"
+	transportProtocolREST        transportProtocol = "rest"
+	transportProtocolGRPC        transportProtocol = "grpc"
 )
 
 type interopExecutor struct{}
@@ -41,6 +50,13 @@ func responseText(message *a2a.Message) string {
 
 func buildTask(execCtx *a2asrv.ExecutorContext, state a2a.TaskState, text string) *a2a.Task {
 	task := a2a.NewSubmittedTask(execCtx, execCtx.Message)
+	if execCtx.StoredTask != nil {
+		history := append([]*a2a.Message{}, execCtx.StoredTask.History...)
+		if execCtx.Message != nil && (len(history) == 0 || history[len(history)-1].ID != execCtx.Message.ID) {
+			history = append(history, execCtx.Message)
+		}
+		task.History = history
+	}
 	task.Status = a2a.TaskStatus{
 		State: state,
 		Message: a2a.NewMessageForTask(
@@ -52,15 +68,100 @@ func buildTask(execCtx *a2asrv.ExecutorContext, state a2a.TaskState, text string
 	return task
 }
 
-func (*interopExecutor) Execute(_ context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
-	state := a2a.TaskStateCompleted
-	if firstText(execCtx.Message) == pendingRequestText {
-		state = a2a.TaskStateWorking
+func buildDataTypesArtifact() *a2a.Artifact {
+	filePart := a2a.NewFileURLPart("https://example.invalid/diagram.svg", "image/svg+xml")
+	filePart.Filename = "diagram.svg"
+
+	return &a2a.Artifact{
+		ID:          a2a.NewArtifactID(),
+		Name:        "data-types-artifact",
+		Description: "Mixed content artifact for scenario parity",
+		Parts: a2a.ContentParts{
+			a2a.NewTextPart("structured summary"),
+			a2a.NewDataPart(map[string]any{"kind": "report", "items": 2}),
+			filePart,
+		},
 	}
-	response := buildTask(execCtx, state, responseText(execCtx.Message))
+}
+
+func buildSkill(id string, description string) a2a.AgentSkill {
+	return a2a.AgentSkill{
+		ID:          id,
+		Name:        id,
+		Description: description,
+		Tags:        []string{"csit", "scenario-parity"},
+	}
+}
+
+func scenarioSkills() []a2a.AgentSkill {
+	return []a2a.AgentSkill{
+		buildSkill("message-only", "Returns a message response without creating a task."),
+		buildSkill("task-lifecycle", "Creates, lists, fetches, and cancels tasks."),
+		buildSkill("task-failure", "Returns a failed task response."),
+		buildSkill("task-cancel", "Creates a cancelable working task."),
+		buildSkill("multi-turn", "Requests more input before completing the task."),
+		buildSkill("streaming", "Streams task and artifact updates."),
+		buildSkill("long-running", "Returns early and completes asynchronously."),
+		buildSkill("data-types", "Produces text, structured data, and URL parts."),
+	}
+}
+
+func (*interopExecutor) Execute(_ context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	requestText := firstText(execCtx.Message)
 
 	return func(yield func(a2a.Event, error) bool) {
-		yield(response, nil)
+		switch requestText {
+		case messageOnlyRequestText:
+			yield(a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("go server message-only response")), nil)
+		case taskFailureRequestText:
+			yield(buildTask(execCtx, a2a.TaskStateFailed, "go server failed task"), nil)
+		case multiTurnStartRequestText:
+			yield(buildTask(execCtx, a2a.TaskStateInputRequired, "go server needs more input"), nil)
+		case multiTurnContinueRequestText:
+			yield(buildTask(execCtx, a2a.TaskStateCompleted, "go server multi-turn completed"), nil)
+		case streamingRequestText:
+			working := buildTask(execCtx, a2a.TaskStateWorking, "go server streaming started")
+			if !yield(working, nil) {
+				return
+			}
+			artifactID := a2a.NewArtifactID()
+			if !yield(&a2a.TaskArtifactUpdateEvent{
+				TaskID:    execCtx.TaskID,
+				ContextID: execCtx.ContextID,
+				Artifact: &a2a.Artifact{
+					ID:    artifactID,
+					Parts: a2a.ContentParts{a2a.NewTextPart("streaming chunk 1")},
+				},
+			}, nil) {
+				return
+			}
+			if !yield(a2a.NewArtifactUpdateEvent(execCtx, artifactID, a2a.NewTextPart("streaming chunk 2")), nil) {
+				return
+			}
+			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, a2a.NewMessageForTask(a2a.MessageRoleAgent, execCtx, a2a.NewTextPart("go server streaming complete"))), nil) {
+				return
+			}
+		case longRunningRequestText:
+			if !yield(buildTask(execCtx, a2a.TaskStateWorking, "go server long-running started"), nil) {
+				return
+			}
+			time.Sleep(150 * time.Millisecond)
+			if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, a2a.NewMessageForTask(a2a.MessageRoleAgent, execCtx, a2a.NewTextPart("go server long-running progress"))), nil) {
+				return
+			}
+			time.Sleep(150 * time.Millisecond)
+			yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, a2a.NewMessageForTask(a2a.MessageRoleAgent, execCtx, a2a.NewTextPart("go server long-running complete"))), nil)
+		case dataTypesRequestText:
+			task := buildTask(execCtx, a2a.TaskStateCompleted, "go server data-types ready")
+			task.Artifacts = []*a2a.Artifact{buildDataTypesArtifact()}
+			yield(task, nil)
+		default:
+			state := a2a.TaskStateCompleted
+			if requestText == pendingRequestText {
+				state = a2a.TaskStateWorking
+			}
+			yield(buildTask(execCtx, state, responseText(execCtx.Message)), nil)
+		}
 	}
 }
 
@@ -108,7 +209,7 @@ func parseTransportProtocol(raw string) (transportProtocol, error) {
 	}
 }
 
-func agentCard(cardPort int, protocol transportProtocol, grpcPort int) *a2a.AgentCard {
+func agentCard(cardPort int, protocol transportProtocol, grpcPort int, extended bool) *a2a.AgentCard {
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", cardPort)
 	name := "CSIT Go JSON-RPC Agent"
 	iface := a2a.NewAgentInterface(baseURL+"/rpc", a2a.TransportProtocolJSONRPC)
@@ -125,18 +226,32 @@ func agentCard(cardPort int, protocol transportProtocol, grpcPort int) *a2a.Agen
 	}
 
 	return &a2a.AgentCard{
-		Name:        name,
-		Description: "Go interoperability fixture for CSIT",
-		Version:     "1.0.0",
+		Name: name,
+		Description: func() string {
+			if extended {
+				return "Go interoperability fixture for CSIT (extended)"
+			}
+			return "Go interoperability fixture for CSIT"
+		}(),
+		Version: "1.0.0",
 		SupportedInterfaces: []*a2a.AgentInterface{
 			iface,
 		},
 		Capabilities: a2a.AgentCapabilities{
 			Streaming:         true,
 			PushNotifications: true,
+			ExtendedAgentCard: true,
 		},
 		DefaultInputModes:  []string{"text/plain"},
 		DefaultOutputModes: []string{"text/plain"},
+		SecuritySchemes: a2a.NamedSecuritySchemes{
+			extendedCardSchemeID: a2a.HTTPAuthSecurityScheme{
+				Scheme:       "Bearer",
+				BearerFormat: "JWT",
+				Description:  "Bearer token authentication",
+			},
+		},
+		Skills: scenarioSkills(),
 	}
 }
 
@@ -203,6 +318,7 @@ func main() {
 			},
 		})),
 		a2asrv.WithPushNotifications(push.NewInMemoryStore(), push.NewHTTPPushSender(nil)),
+		a2asrv.WithExtendedAgentCard(agentCard(*port, protocol, *grpcPort, true)),
 	)
 
 	if protocol == transportProtocolGRPC {
@@ -216,7 +332,7 @@ func main() {
 			log.Fatalf("failed to bind gRPC listener: %v", err)
 		}
 
-		card := agentCard(*port, protocol, *grpcPort)
+		card := agentCard(*port, protocol, *grpcPort, false)
 		errCh := make(chan error, 2)
 
 		go func() {
@@ -252,7 +368,7 @@ func main() {
 		mux.Handle("/", wrapRESTPushCreateCompat(a2asrv.NewRESTHandler(handler)))
 		log.Printf("go rest fixture listening on http://127.0.0.1:%d", *port)
 	}
-	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(agentCard(*port, protocol, *grpcPort)))
+	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(agentCard(*port, protocol, *grpcPort, false)))
 
 	if err := http.Serve(listener, mux); err != nil {
 		log.Fatalf("server stopped: %v", err)

--- a/integrations/agntcy-a2a/fixtures/rust/Cargo.lock
+++ b/integrations/agntcy-a2a/fixtures/rust/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "agntcy-a2a-grpc",
  "agntcy-a2a-pb",
  "agntcy-a2a-server",
+ "async-trait",
  "axum",
  "futures",
  "serde_json",

--- a/integrations/agntcy-a2a/fixtures/rust/Cargo.toml
+++ b/integrations/agntcy-a2a/fixtures/rust/Cargo.toml
@@ -10,8 +10,9 @@ a2a-client = { package = "agntcy-a2a-client", version = "0.1.13" }
 a2a-grpc = { package = "agntcy-a2a-grpc", version = "0.1.11" }
 a2a-pb = { package = "agntcy-a2a-pb", version = "0.1.6" }
 a2a-server = { package = "agntcy-a2a-server", version = "0.2.6" }
+async-trait = "0.1"
 axum = "0.8"
 futures = "0.3"
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
 tonic = { version = "0.13", features = ["transport"] }

--- a/integrations/agntcy-a2a/fixtures/rust/src/bin/interop-rust-probe.rs
+++ b/integrations/agntcy-a2a/fixtures/rust/src/bin/interop-rust-probe.rs
@@ -4,6 +4,7 @@
 use std::env;
 use std::process;
 use std::sync::Arc;
+use std::time::Duration;
 
 use a2a::*;
 use a2a_client::A2AClientFactory;
@@ -12,13 +13,32 @@ use a2a_grpc::GrpcTransportFactory;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use serde_json::{Value, json};
+use tokio::time::sleep;
 
 const REQUEST_TEXT: &str = "ping";
 const PENDING_REQUEST_TEXT: &str = "pending";
+const MESSAGE_ONLY_REQUEST_TEXT: &str = "message-only";
+const TASK_FAILURE_REQUEST_TEXT: &str = "task-failure";
+const MULTI_TURN_START_REQUEST_TEXT: &str = "multi-turn start";
+const MULTI_TURN_CONTINUE_REQUEST_TEXT: &str = "multi-turn continue";
+const STREAMING_REQUEST_TEXT: &str = "streaming";
+const LONG_RUNNING_REQUEST_TEXT: &str = "long-running";
+const DATA_TYPES_REQUEST_TEXT: &str = "data-types";
 const REQUEST_DATA_KIND: &str = "structured";
 const REQUEST_DATA_SCOPE: &str = "interop";
 const REQUEST_METADATA_KEY: &str = "csit";
 const REQUEST_METADATA_VALUE: &str = "multipart";
+const EXTENDED_CARD_SCHEME_ID: &str = "bearer_token";
+const EXPECTED_SKILL_IDS: &[&str] = &[
+    "message-only",
+    "task-lifecycle",
+    "task-failure",
+    "task-cancel",
+    "multi-turn",
+    "streaming",
+    "long-running",
+    "data-types",
+];
 
 struct Args {
     card_url: String,
@@ -209,7 +229,20 @@ fn expected_cancel_text(server_prefix: &str) -> String {
     format!("{server_prefix} server canceled task")
 }
 
+fn expected_scenario_text(server_prefix: &str, suffix: &str) -> String {
+    format!("{server_prefix} server {suffix}")
+}
+
 fn request_with_payload(text: &str, return_immediately: bool) -> SendMessageRequest {
+    request_with_payload_ids(text, return_immediately, None, None)
+}
+
+fn request_with_payload_ids(
+    text: &str,
+    return_immediately: bool,
+    task_id: Option<String>,
+    context_id: Option<String>,
+) -> SendMessageRequest {
     let mut message = Message::new(
         Role::User,
         vec![
@@ -220,6 +253,8 @@ fn request_with_payload(text: &str, return_immediately: bool) -> SendMessageRequ
             })),
         ],
     );
+    message.task_id = task_id;
+    message.context_id = context_id;
     message.metadata = Some(std::collections::HashMap::from([(
         REQUEST_METADATA_KEY.to_string(),
         json!(REQUEST_METADATA_VALUE),
@@ -253,6 +288,13 @@ fn task_from_response(response: SendMessageResponse, kind: &str) -> Result<Task,
     }
 }
 
+fn message_from_response(response: SendMessageResponse, kind: &str) -> Result<Message, String> {
+    match response {
+        SendMessageResponse::Task(_) => Err(format!("unexpected {kind} response type: Task")),
+        SendMessageResponse::Message(message) => Ok(message),
+    }
+}
+
 fn stream_response_text(response: StreamResponse) -> Result<Option<String>, String> {
     match response {
         StreamResponse::Message(message) => first_text(&message).map(Some),
@@ -264,18 +306,10 @@ fn stream_response_text(response: StreamResponse) -> Result<Option<String>, Stri
     }
 }
 
-fn assert_task_history(task: &Task, expected_text: &str, kind: &str) -> Result<(), String> {
-    let history = task
-        .history
-        .as_ref()
-        .ok_or_else(|| format!("{kind} task did not include history"))?;
-    let message = history
-        .last()
-        .ok_or_else(|| format!("{kind} task history was empty"))?;
-
+fn assert_message_payload(message: &Message, expected_text: &str, kind: &str) -> Result<(), String> {
     if message.parts.len() != 2 {
         return Err(format!(
-            "{kind} task history had {} parts, want 2",
+            "{kind} message had {} parts, want 2",
             message.parts.len()
         ));
     }
@@ -287,43 +321,193 @@ fn assert_task_history(task: &Task, expected_text: &str, kind: &str) -> Result<(
         PartContent::Data(value) => value,
         _ => {
             return Err(format!(
-                "{kind} task history second part was not a structured data part"
+                "{kind} message second part was not a structured data part"
             ));
         }
     };
     let kind_value = part_data
         .get("kind")
         .and_then(Value::as_str)
-        .ok_or_else(|| format!("{kind} task history data part was missing kind"))?;
+        .ok_or_else(|| format!("{kind} message data part was missing kind"))?;
     let scope_value = part_data
         .get("scope")
         .and_then(Value::as_str)
-        .ok_or_else(|| format!("{kind} task history data part was missing scope"))?;
+        .ok_or_else(|| format!("{kind} message data part was missing scope"))?;
 
     if kind_value != REQUEST_DATA_KIND || scope_value != REQUEST_DATA_SCOPE {
         return Err(format!(
-            "{kind} task history data part mismatch: got kind={kind_value:?} scope={scope_value:?}"
+            "{kind} message data part mismatch: got kind={kind_value:?} scope={scope_value:?}"
         ));
     }
 
     let metadata = message
         .metadata
         .as_ref()
-        .ok_or_else(|| format!("{kind} task history message was missing metadata"))?;
+        .ok_or_else(|| format!("{kind} message was missing metadata"))?;
     let metadata_value = metadata
         .get(REQUEST_METADATA_KEY)
         .and_then(Value::as_str)
-        .ok_or_else(|| {
-            format!("{kind} task history metadata was missing {REQUEST_METADATA_KEY}")
-        })?;
+        .ok_or_else(|| format!("{kind} message metadata was missing {REQUEST_METADATA_KEY}"))?;
 
     if metadata_value != REQUEST_METADATA_VALUE {
         return Err(format!(
-            "{kind} task history metadata mismatch: got {metadata_value:?}, want {REQUEST_METADATA_VALUE:?}"
+            "{kind} message metadata mismatch: got {metadata_value:?}, want {REQUEST_METADATA_VALUE:?}"
         ));
     }
 
     Ok(())
+}
+
+fn assert_task_history(task: &Task, expected_text: &str, kind: &str) -> Result<(), String> {
+    assert_task_history_entries(task, &[expected_text], kind)
+}
+
+fn assert_task_history_entries(task: &Task, expected_texts: &[&str], kind: &str) -> Result<(), String> {
+    let history = task
+        .history
+        .as_ref()
+        .ok_or_else(|| format!("{kind} task did not include history"))?;
+    if history.len() != expected_texts.len() {
+        return Err(format!(
+            "{kind} task history length mismatch: got {}, want {}",
+            history.len(),
+            expected_texts.len()
+        ));
+    }
+
+    for (message, expected_text) in history.iter().zip(expected_texts.iter()) {
+        assert_message_payload(message, expected_text, kind)?;
+    }
+
+    Ok(())
+}
+
+fn first_artifact_text(artifact: &Artifact) -> Result<String, String> {
+    artifact
+        .parts
+        .iter()
+        .find_map(Part::as_text)
+        .map(ToString::to_string)
+        .ok_or_else(|| "artifact contained no text parts".to_string())
+}
+
+fn assert_data_types_task(task: &Task, kind: &str) -> Result<(), String> {
+    let artifacts = task
+        .artifacts
+        .as_ref()
+        .ok_or_else(|| format!("{kind} task did not include artifacts"))?;
+    if artifacts.len() != 1 {
+        return Err(format!(
+            "{kind} task artifact count mismatch: got {}, want 1",
+            artifacts.len()
+        ));
+    }
+
+    let artifact = &artifacts[0];
+    if artifact.parts.len() != 3 {
+        return Err(format!(
+            "{kind} artifact part count mismatch: got {}, want 3",
+            artifact.parts.len()
+        ));
+    }
+
+    assert_text(first_artifact_text(artifact)?, "structured summary", kind)?;
+
+    match &artifact.parts[1].content {
+        PartContent::Data(value) => {
+            if value.get("kind").and_then(Value::as_str) != Some("report") {
+                return Err(format!("{kind} data-types artifact was missing kind=report"));
+            }
+            let items_matches = value
+                .get("items")
+                .map(|items| {
+                    items.as_i64() == Some(2)
+                        || items.as_u64() == Some(2)
+                        || items.as_f64() == Some(2.0)
+                })
+                .unwrap_or(false);
+            if !items_matches {
+                return Err(format!("{kind} data-types artifact was missing items=2"));
+            }
+        }
+        _ => return Err(format!("{kind} data-types artifact second part was not data")),
+    }
+
+    match &artifact.parts[2].content {
+        PartContent::Url(url) => {
+            if url != "https://example.invalid/diagram.svg" {
+                return Err(format!("{kind} data-types artifact URL mismatch: got {url:?}"));
+            }
+        }
+        _ => return Err(format!("{kind} data-types artifact third part was not a URL")),
+    }
+
+    if artifact.parts[2].media_type.as_deref() != Some("image/svg+xml") {
+        return Err(format!("{kind} data-types artifact media type mismatch"));
+    }
+    if artifact.parts[2].filename.as_deref() != Some("diagram.svg") {
+        return Err(format!("{kind} data-types artifact filename mismatch"));
+    }
+
+    Ok(())
+}
+
+fn assert_extended_card_metadata(card: &AgentCard, kind: &str) -> Result<(), String> {
+    if card.capabilities.extended_agent_card != Some(true) {
+        return Err(format!("{kind} card did not advertise extendedAgentCard support"));
+    }
+    if !card.description.contains("(extended)") {
+        return Err(format!("{kind} card did not include extended description metadata"));
+    }
+
+    if let Some(schemes) = card.security_schemes.as_ref() {
+        let scheme = schemes
+            .get(EXTENDED_CARD_SCHEME_ID)
+            .ok_or_else(|| format!("{kind} card did not include {EXTENDED_CARD_SCHEME_ID}"))?;
+
+        match scheme {
+            SecurityScheme::HttpAuth(http) => {
+                if http.scheme != "Bearer" {
+                    return Err(format!("{kind} bearer scheme mismatch: got {:?}", http.scheme));
+                }
+            }
+            _ => return Err(format!("{kind} card security scheme was not HTTP auth")),
+        }
+    }
+
+    for expected_skill in EXPECTED_SKILL_IDS {
+        if !card.skills.iter().any(|skill| skill.id == *expected_skill) {
+            return Err(format!("{kind} card was missing skill {expected_skill}"));
+        }
+    }
+
+    Ok(())
+}
+
+async fn wait_for_task_state(
+    client: &a2a_client::client::A2AClient,
+    task_id: &str,
+    expected_state: TaskState,
+    kind: &str,
+) -> Result<Task, String> {
+    for _ in 0..40 {
+        let task = client
+            .get_task(&GetTaskRequest {
+                id: task_id.to_string(),
+                history_length: None,
+                tenant: None,
+            })
+            .await
+            .map_err(|error| format!("{kind} get_task failed: {error}"))?;
+
+        if task.status.state == expected_state {
+            return Ok(task);
+        }
+
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    Err(format!("timed out waiting for {kind} to reach state {expected_state:?}"))
 }
 
 #[tokio::main]
@@ -363,6 +547,15 @@ async fn run(args: Args) -> Result<(), String> {
     let expected_ping_text = expected_response_text(&args.server_prefix, REQUEST_TEXT);
     let expected_pending_text = expected_response_text(&args.server_prefix, PENDING_REQUEST_TEXT);
     let expected_cancel_text = expected_cancel_text(&args.server_prefix);
+    let expected_message_only_text = expected_scenario_text(&args.server_prefix, "message-only response");
+    let expected_failed_text = expected_scenario_text(&args.server_prefix, "failed task");
+    let expected_input_required_text = expected_scenario_text(&args.server_prefix, "needs more input");
+    let expected_multi_turn_complete_text = expected_scenario_text(&args.server_prefix, "multi-turn completed");
+    let expected_streaming_start_text = expected_scenario_text(&args.server_prefix, "streaming started");
+    let expected_streaming_complete_text = expected_scenario_text(&args.server_prefix, "streaming complete");
+    let expected_long_running_start_text = expected_scenario_text(&args.server_prefix, "long-running started");
+    let expected_long_running_complete_text = expected_scenario_text(&args.server_prefix, "long-running complete");
+    let expected_data_types_text = expected_scenario_text(&args.server_prefix, "data-types ready");
 
     let request = request_with_payload(REQUEST_TEXT, false);
 
@@ -741,6 +934,172 @@ async fn run(args: Args) -> Result<(), String> {
             ));
         }
     }
+
+    let message_only = message_from_response(
+        client
+            .send_message(&request_with_payload(MESSAGE_ONLY_REQUEST_TEXT, false))
+            .await
+            .map_err(|error| format!("message-only request failed: {error}"))?,
+        "message-only",
+    )?;
+    assert_text(
+        first_text(&message_only)?,
+        &expected_message_only_text,
+        "message-only",
+    )?;
+
+    let failed_task = task_from_response(
+        client
+            .send_message(&request_with_payload(TASK_FAILURE_REQUEST_TEXT, false))
+            .await
+            .map_err(|error| format!("task-failure request failed: {error}"))?,
+        "task-failure",
+    )?;
+    assert_state(&failed_task.status.state, TaskState::Failed, "task-failure")?;
+    assert_text(task_text(&failed_task)?, &expected_failed_text, "task-failure")?;
+
+    let input_required_task = task_from_response(
+        client
+            .send_message(&request_with_payload(MULTI_TURN_START_REQUEST_TEXT, false))
+            .await
+            .map_err(|error| format!("multi-turn start failed: {error}"))?,
+        "multi-turn start",
+    )?;
+    assert_state(
+        &input_required_task.status.state,
+        TaskState::InputRequired,
+        "multi-turn start",
+    )?;
+    assert_text(
+        task_text(&input_required_task)?,
+        &expected_input_required_text,
+        "multi-turn start",
+    )?;
+    assert_task_history(&input_required_task, MULTI_TURN_START_REQUEST_TEXT, "multi-turn start")?;
+
+    let multi_turn_completed = task_from_response(
+        client
+            .send_message(&request_with_payload_ids(
+                MULTI_TURN_CONTINUE_REQUEST_TEXT,
+                false,
+                Some(input_required_task.id.clone()),
+                Some(input_required_task.context_id.clone()),
+            ))
+            .await
+            .map_err(|error| format!("multi-turn continuation failed: {error}"))?,
+        "multi-turn continuation",
+    )?;
+    assert_state(
+        &multi_turn_completed.status.state,
+        TaskState::Completed,
+        "multi-turn continuation",
+    )?;
+    assert_text(
+        task_text(&multi_turn_completed)?,
+        &expected_multi_turn_complete_text,
+        "multi-turn continuation",
+    )?;
+    assert_task_history_entries(
+        &multi_turn_completed,
+        &[MULTI_TURN_START_REQUEST_TEXT, MULTI_TURN_CONTINUE_REQUEST_TEXT],
+        "multi-turn continuation",
+    )?;
+
+    let mut scenario_stream = client
+        .send_streaming_message(&request_with_payload(STREAMING_REQUEST_TEXT, false))
+        .await
+        .map_err(|error| format!("streaming scenario request failed: {error}"))?;
+    let mut streaming_chunks = Vec::new();
+    let mut saw_append = false;
+    let mut saw_stream_start = false;
+    let mut saw_stream_complete = false;
+    while let Some(event) = scenario_stream.next().await {
+        let event = event.map_err(|error| format!("streaming scenario event failed: {error}"))?;
+        match event {
+            StreamResponse::Task(task) => {
+                saw_stream_start = true;
+                assert_state(&task.status.state, TaskState::Working, "streaming scenario task")?;
+                assert_text(task_text(&task)?, &expected_streaming_start_text, "streaming scenario task")?;
+            }
+            StreamResponse::ArtifactUpdate(update) => {
+                streaming_chunks.push(first_artifact_text(&update.artifact)?);
+                if update.append == Some(true) {
+                    saw_append = true;
+                }
+            }
+            StreamResponse::StatusUpdate(update) => {
+                assert_state(&update.status.state, TaskState::Completed, "streaming scenario status")?;
+                assert_text(
+                    first_text(update.status.message.as_ref().ok_or_else(|| "streaming scenario completion was missing a message".to_string())?)?,
+                    &expected_streaming_complete_text,
+                    "streaming scenario status",
+                )?;
+                saw_stream_complete = true;
+            }
+            StreamResponse::Message(_) => return Err("streaming scenario yielded an unexpected message event".to_string()),
+        }
+    }
+    if !saw_stream_start || !saw_stream_complete {
+        return Err("streaming scenario did not emit the expected task/status events".to_string());
+    }
+    if streaming_chunks != vec!["streaming chunk 1".to_string(), "streaming chunk 2".to_string()] {
+        return Err(format!("streaming scenario artifact chunks mismatch: got {streaming_chunks:?}"));
+    }
+    if !saw_append {
+        return Err("streaming scenario did not emit an append artifact update".to_string());
+    }
+
+    let long_running_task = task_from_response(
+        client
+            .send_message(&request_with_payload(LONG_RUNNING_REQUEST_TEXT, true))
+            .await
+            .map_err(|error| format!("long-running request failed: {error}"))?,
+        "long-running",
+    )?;
+    let long_running_completed = match long_running_task.status.state {
+        TaskState::Working => {
+            assert_text(
+                task_text(&long_running_task)?,
+                &expected_long_running_start_text,
+                "long-running",
+            )?;
+            wait_for_task_state(
+                &client,
+                &long_running_task.id,
+                TaskState::Completed,
+                "long-running",
+            )
+            .await?
+        }
+        TaskState::Completed => long_running_task,
+        ref other => {
+            return Err(format!(
+                "unexpected long-running task state: got {other:?}, want Working or Completed"
+            ));
+        }
+    };
+    assert_text(
+        task_text(&long_running_completed)?,
+        &expected_long_running_complete_text,
+        "long-running completion",
+    )?;
+
+    let data_types_task = task_from_response(
+        client
+            .send_message(&request_with_payload(DATA_TYPES_REQUEST_TEXT, false))
+            .await
+            .map_err(|error| format!("data-types request failed: {error}"))?,
+        "data-types",
+    )?;
+    assert_state(&data_types_task.status.state, TaskState::Completed, "data-types")?;
+    assert_text(task_text(&data_types_task)?, &expected_data_types_text, "data-types")?;
+    assert_data_types_task(&data_types_task, "data-types")?;
+
+    let extended_card = client
+        .get_extended_agent_card(&GetExtendedAgentCardRequest { tenant: None })
+        .await
+        .map_err(|error| format!("get_extended_agent_card failed: {error}"))?;
+    assert_extended_card_metadata(&extended_card, "extended-card")?;
 
     let protocol = card
         .supported_interfaces

--- a/integrations/agntcy-a2a/fixtures/rust/src/bin/interop-rust-server.rs
+++ b/integrations/agntcy-a2a/fixtures/rust/src/bin/interop-rust-server.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::env;
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use a2a::*;
 use a2a_grpc::GrpcHandler;
@@ -10,12 +12,23 @@ use a2a_pb::proto::a2a_service_server::A2aServiceServer;
 use a2a_server::{
     DefaultRequestHandler, InMemoryPushConfigStore, InMemoryTaskStore, StaticAgentCard,
 };
+use async_trait::async_trait;
 use axum::Router;
+use futures::StreamExt;
 use futures::stream::{self, BoxStream};
 use tokio::net::TcpListener;
+use tokio::time::sleep;
 use tonic::transport::Server;
 
 const PENDING_REQUEST_TEXT: &str = "pending";
+const MESSAGE_ONLY_REQUEST_TEXT: &str = "message-only";
+const TASK_FAILURE_REQUEST_TEXT: &str = "task-failure";
+const MULTI_TURN_START_REQUEST_TEXT: &str = "multi-turn start";
+const MULTI_TURN_CONTINUE_REQUEST_TEXT: &str = "multi-turn continue";
+const STREAMING_REQUEST_TEXT: &str = "streaming";
+const LONG_RUNNING_REQUEST_TEXT: &str = "long-running";
+const DATA_TYPES_REQUEST_TEXT: &str = "data-types";
+const EXTENDED_CARD_SCHEME_ID: &str = "bearer_token";
 
 #[derive(Clone, Copy)]
 enum TransportProtocol {
@@ -45,6 +58,11 @@ impl TransportProtocol {
 
 struct InteropExecutor;
 
+struct InteropHandler {
+    inner: DefaultRequestHandler,
+    extended_card: AgentCard,
+}
+
 fn first_text(message: Option<&Message>) -> String {
     message
         .and_then(|message| message.parts.iter().find_map(Part::as_text))
@@ -56,6 +74,7 @@ fn build_agent_card(
     card_port: u16,
     protocol: TransportProtocol,
     grpc_port: Option<u16>,
+    extended: bool,
 ) -> AgentCard {
     let base_url = format!("http://127.0.0.1:{card_port}");
     let (name, interface_url, binding) = match protocol {
@@ -81,35 +100,62 @@ fn build_agent_card(
 
     AgentCard {
         name: name.to_string(),
-        description: "Rust interoperability fixture for CSIT".to_string(),
+        description: if extended {
+            "Rust interoperability fixture for CSIT (extended)".to_string()
+        } else {
+            "Rust interoperability fixture for CSIT".to_string()
+        },
         version: VERSION.to_string(),
         supported_interfaces: vec![AgentInterface::new(interface_url, binding)],
         capabilities: AgentCapabilities {
             streaming: Some(true),
             push_notifications: Some(true),
             extensions: None,
-            extended_agent_card: None,
+            extended_agent_card: Some(true),
         },
         default_input_modes: vec!["text/plain".to_string()],
         default_output_modes: vec!["text/plain".to_string()],
-        skills: vec![],
+        skills: scenario_skills(),
         provider: None,
         documentation_url: None,
         icon_url: None,
-        security_schemes: None,
+        security_schemes: Some(HashMap::from([(
+            EXTENDED_CARD_SCHEME_ID.to_string(),
+            SecurityScheme::HttpAuth(HttpAuthSecurityScheme {
+                scheme: "Bearer".to_string(),
+                description: Some("Bearer token authentication".to_string()),
+                bearer_format: Some("JWT".to_string()),
+            }),
+        )])),
         security_requirements: None,
         signatures: None,
     }
 }
 
-fn build_response_message(request: Option<&Message>) -> Message {
-    Message::new(
-        Role::Agent,
-        vec![Part::text(format!(
-            "rust server received: {}",
-            first_text(request)
-        ))],
-    )
+fn scenario_skills() -> Vec<AgentSkill> {
+    vec![
+        build_skill("message-only", "Returns a message response without creating a task."),
+        build_skill("task-lifecycle", "Creates, lists, fetches, and cancels tasks."),
+        build_skill("task-failure", "Returns a failed task response."),
+        build_skill("task-cancel", "Creates a cancelable working task."),
+        build_skill("multi-turn", "Requests more input before completing the task."),
+        build_skill("streaming", "Streams task and artifact updates."),
+        build_skill("long-running", "Returns early and completes asynchronously."),
+        build_skill("data-types", "Produces text, structured data, and URL parts."),
+    ]
+}
+
+fn build_skill(id: &str, description: &str) -> AgentSkill {
+    AgentSkill {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: description.to_string(),
+        tags: vec!["csit".to_string(), "scenario-parity".to_string()],
+        examples: None,
+        input_modes: None,
+        output_modes: None,
+        security_requirements: None,
+    }
 }
 
 fn build_task_message(task_id: &str, context_id: &str, text: impl Into<String>) -> Message {
@@ -124,6 +170,21 @@ fn build_task(
     state: TaskState,
     text: impl Into<String>,
 ) -> Task {
+    let mut history = ctx
+        .stored_task
+        .as_ref()
+        .and_then(|task| task.history.clone())
+        .unwrap_or_default();
+    if let Some(message) = ctx.message.clone() {
+        let should_append = history
+            .last()
+            .map(|entry| entry.message_id != message.message_id)
+            .unwrap_or(true);
+        if should_append {
+            history.push(message);
+        }
+    }
+
     let mut task = Task {
         id: ctx.task_id.clone(),
         context_id: ctx.context_id.clone(),
@@ -133,7 +194,7 @@ fn build_task(
             timestamp: None,
         },
         artifacts: None,
-        history: ctx.message.clone().map(|message| vec![message]),
+        history: (!history.is_empty()).then_some(history),
         metadata: None,
     };
     task.status.message = Some(build_task_message(&task.id, &task.context_id, text));
@@ -157,19 +218,271 @@ fn build_status_update(
     }
 }
 
+fn build_artifact_update(
+    ctx: &a2a_server::ExecutorContext,
+    artifact_id: &str,
+    parts: Vec<Part>,
+    append: bool,
+    last_chunk: bool,
+) -> TaskArtifactUpdateEvent {
+    TaskArtifactUpdateEvent {
+        task_id: ctx.task_id.clone(),
+        context_id: ctx.context_id.clone(),
+        artifact: Artifact {
+            artifact_id: artifact_id.to_string(),
+            name: Some(artifact_id.to_string()),
+            description: None,
+            parts,
+            metadata: None,
+            extensions: None,
+        },
+        append: Some(append),
+        last_chunk: Some(last_chunk),
+        metadata: None,
+    }
+}
+
+fn build_data_types_artifact(task_id: &str) -> Artifact {
+    Artifact {
+        artifact_id: format!("{task_id}-artifact"),
+        name: Some("data-types-artifact".to_string()),
+        description: Some("Mixed content artifact for scenario parity".to_string()),
+        parts: vec![
+            Part::text("structured summary"),
+            Part::data(serde_json::json!({
+                "kind": "report",
+                "items": 2,
+            })),
+            Part::url("https://example.invalid/diagram.svg")
+                .with_media_type("image/svg+xml")
+                .with_filename("diagram.svg"),
+        ],
+        metadata: None,
+        extensions: None,
+    }
+}
+
+fn message_text(ctx: &a2a_server::ExecutorContext) -> String {
+    first_text(ctx.message.as_ref())
+}
+
+impl InteropHandler {
+    fn new(inner: DefaultRequestHandler, extended_card: AgentCard) -> Self {
+        Self {
+            inner,
+            extended_card,
+        }
+    }
+}
+
+#[async_trait]
+impl a2a_server::RequestHandler for InteropHandler {
+    async fn send_message(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: SendMessageRequest,
+    ) -> Result<SendMessageResponse, A2AError> {
+        self.inner.send_message(params, req).await
+    }
+
+    async fn send_streaming_message(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: SendMessageRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.inner.send_streaming_message(params, req).await
+    }
+
+    async fn get_task(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: GetTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.inner.get_task(params, req).await
+    }
+
+    async fn list_tasks(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
+        self.inner.list_tasks(params, req).await
+    }
+
+    async fn cancel_task(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: CancelTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.inner.cancel_task(params, req).await
+    }
+
+    async fn subscribe_to_task(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: SubscribeToTaskRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.inner.subscribe_to_task(params, req).await
+    }
+
+    async fn create_push_config(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: CreateTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        self.inner.create_push_config(params, req).await
+    }
+
+    async fn get_push_config(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: GetTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        self.inner.get_push_config(params, req).await
+    }
+
+    async fn list_push_configs(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: ListTaskPushNotificationConfigsRequest,
+    ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+        self.inner.list_push_configs(params, req).await
+    }
+
+    async fn delete_push_config(
+        &self,
+        params: &a2a_server::ServiceParams,
+        req: DeleteTaskPushNotificationConfigRequest,
+    ) -> Result<(), A2AError> {
+        self.inner.delete_push_config(params, req).await
+    }
+
+    async fn get_extended_agent_card(
+        &self,
+        _params: &a2a_server::ServiceParams,
+        _req: GetExtendedAgentCardRequest,
+    ) -> Result<AgentCard, A2AError> {
+        Ok(self.extended_card.clone())
+    }
+}
+
 impl a2a_server::AgentExecutor for InteropExecutor {
     fn execute(
         &self,
         ctx: a2a_server::ExecutorContext,
     ) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
-        let response_text = format!("rust server received: {}", first_text(ctx.message.as_ref()));
-        let state = if first_text(ctx.message.as_ref()) == PENDING_REQUEST_TEXT {
-            TaskState::Working
-        } else {
-            TaskState::Completed
-        };
-        let response = StreamResponse::Task(build_task(&ctx, state, response_text));
-        Box::pin(stream::once(async move { Ok(response) }))
+        let request_text = message_text(&ctx);
+
+        match request_text.as_str() {
+            MESSAGE_ONLY_REQUEST_TEXT => {
+                let response = StreamResponse::Message(Message::new(
+                    Role::Agent,
+                    vec![Part::text("rust server message-only response")],
+                ));
+                Box::pin(stream::once(async move { Ok(response) }))
+            }
+            TASK_FAILURE_REQUEST_TEXT => {
+                let response = StreamResponse::Task(build_task(
+                    &ctx,
+                    TaskState::Failed,
+                    "rust server failed task",
+                ));
+                Box::pin(stream::once(async move { Ok(response) }))
+            }
+            MULTI_TURN_START_REQUEST_TEXT => {
+                let response = StreamResponse::Task(build_task(
+                    &ctx,
+                    TaskState::InputRequired,
+                    "rust server needs more input",
+                ));
+                Box::pin(stream::once(async move { Ok(response) }))
+            }
+            MULTI_TURN_CONTINUE_REQUEST_TEXT => {
+                let response = StreamResponse::Task(build_task(
+                    &ctx,
+                    TaskState::Completed,
+                    "rust server multi-turn completed",
+                ));
+                Box::pin(stream::once(async move { Ok(response) }))
+            }
+            STREAMING_REQUEST_TEXT => {
+                let working = StreamResponse::Task(build_task(
+                    &ctx,
+                    TaskState::Working,
+                    "rust server streaming started",
+                ));
+                let artifact_id = format!("{}-stream", ctx.task_id);
+                let first_artifact = StreamResponse::ArtifactUpdate(build_artifact_update(
+                    &ctx,
+                    &artifact_id,
+                    vec![Part::text("streaming chunk 1")],
+                    false,
+                    false,
+                ));
+                let second_artifact = StreamResponse::ArtifactUpdate(build_artifact_update(
+                    &ctx,
+                    &artifact_id,
+                    vec![Part::text("streaming chunk 2")],
+                    true,
+                    true,
+                ));
+                let completed = StreamResponse::StatusUpdate(build_status_update(
+                    &ctx,
+                    TaskState::Completed,
+                    "rust server streaming complete",
+                ));
+                Box::pin(stream::iter(vec![
+                    Ok(working),
+                    Ok(first_artifact),
+                    Ok(second_artifact),
+                    Ok(completed),
+                ]))
+            }
+            LONG_RUNNING_REQUEST_TEXT => {
+                let started = StreamResponse::Task(build_task(
+                    &ctx,
+                    TaskState::Working,
+                    "rust server long-running started",
+                ));
+                let progress = StreamResponse::StatusUpdate(build_status_update(
+                    &ctx,
+                    TaskState::Working,
+                    "rust server long-running progress",
+                ));
+                let completed = StreamResponse::StatusUpdate(build_status_update(
+                    &ctx,
+                    TaskState::Completed,
+                    "rust server long-running complete",
+                ));
+                Box::pin(
+                    stream::once(async move { Ok(started) })
+                        .chain(stream::once(async move {
+                            sleep(Duration::from_millis(150)).await;
+                            Ok(progress)
+                        }))
+                        .chain(stream::once(async move {
+                            sleep(Duration::from_millis(150)).await;
+                            Ok(completed)
+                        })),
+                )
+            }
+            DATA_TYPES_REQUEST_TEXT => {
+                let mut task = build_task(&ctx, TaskState::Completed, "rust server data-types ready");
+                task.artifacts = Some(vec![build_data_types_artifact(&ctx.task_id)]);
+                let response = StreamResponse::Task(task);
+                Box::pin(stream::once(async move { Ok(response) }))
+            }
+            _ => {
+                let response_text = format!("rust server received: {request_text}");
+                let state = if request_text == PENDING_REQUEST_TEXT {
+                    TaskState::Working
+                } else {
+                    TaskState::Completed
+                };
+                let response = StreamResponse::Task(build_task(&ctx, state, response_text));
+                Box::pin(stream::once(async move { Ok(response) }))
+            }
+        }
     }
 
     fn cancel(
@@ -223,13 +536,14 @@ fn parse_args() -> (u16, TransportProtocol, Option<u16>) {
 #[tokio::main]
 async fn main() {
     let (port, protocol, grpc_port) = parse_args();
-    let handler = Arc::new(
+    let public_card = build_agent_card(port, protocol, grpc_port, false);
+    let extended_card = build_agent_card(port, protocol, grpc_port, true);
+    let handler = Arc::new(InteropHandler::new(
         DefaultRequestHandler::new(InteropExecutor, InMemoryTaskStore::new())
             .with_push_config_store(InMemoryPushConfigStore::new()),
-    );
-    let card_producer = Arc::new(StaticAgentCard::new(build_agent_card(
-        port, protocol, grpc_port,
-    )));
+        extended_card,
+    ));
+    let card_producer = Arc::new(StaticAgentCard::new(public_card));
 
     let app = match protocol {
         TransportProtocol::JsonRpc => Router::new()

--- a/integrations/agntcy-a2a/tests/interop_rust_go_test.go
+++ b/integrations/agntcy-a2a/tests/interop_rust_go_test.go
@@ -28,16 +28,28 @@ import (
 )
 
 const (
-	fixtureReadyTimeout  = 20 * time.Second
-	probeTimeout         = 2 * time.Minute
-	buildTimeout         = 3 * time.Minute
-	stopTimeout          = 5 * time.Second
-	requestText          = "ping"
-	pendingRequestText   = "pending"
-	requestDataKind      = "structured"
-	requestDataScope     = "interop"
-	requestMetadataKey   = "csit"
-	requestMetadataValue = "multipart"
+	fixtureReadyTimeout          = 20 * time.Second
+	probeTimeout                 = 2 * time.Minute
+	buildTimeout                 = 3 * time.Minute
+	stopTimeout                  = 5 * time.Second
+	requestText                  = "ping"
+	pendingRequestText           = "pending"
+	messageOnlyRequestText       = "message-only"
+	taskFailureRequestText       = "task-failure"
+	multiTurnStartRequestText    = "multi-turn start"
+	multiTurnContinueRequestText = "multi-turn continue"
+	streamingRequestText         = "streaming"
+	longRunningRequestText       = "long-running"
+	dataTypesRequestText         = "data-types"
+	requestDataKind              = "structured"
+	requestDataScope             = "interop"
+	requestMetadataKey           = "csit"
+	requestMetadataValue         = "multipart"
+)
+
+var (
+	extendedCardSchemeID = a2a.SecuritySchemeName("bearer_token")
+	expectedSkillIDs     = []string{"message-only", "task-lifecycle", "task-failure", "task-cancel", "multi-turn", "streaming", "long-running", "data-types"}
 )
 
 type transportProtocol string
@@ -344,6 +356,10 @@ func newGoClient(ctx context.Context, baseURL string) (*a2aclient.Client, error)
 }
 
 func newInteropRequest(text string, returnImmediately bool) *a2a.SendMessageRequest {
+	return newInteropRequestWithIDs(text, returnImmediately, "", "")
+}
+
+func newInteropRequestWithIDs(text string, returnImmediately bool, taskID a2a.TaskID, contextID string) *a2a.SendMessageRequest {
 	message := a2a.NewMessage(
 		a2a.MessageRoleUser,
 		a2a.NewTextPart(text),
@@ -352,6 +368,12 @@ func newInteropRequest(text string, returnImmediately bool) *a2a.SendMessageRequ
 			"scope": requestDataScope,
 		}),
 	)
+	if taskID != "" {
+		message.TaskID = taskID
+	}
+	if contextID != "" {
+		message.ContextID = contextID
+	}
 	message.Metadata = map[string]any{
 		requestMetadataKey: requestMetadataValue,
 	}
@@ -380,8 +402,14 @@ func assertMessageInteropPayload(message *a2a.Message, expectedText string, kind
 }
 
 func assertTaskHistoryPayload(task *a2a.Task, expectedText string, kind string) {
-	gomega.Expect(task.History).To(gomega.HaveLen(1), kind)
-	assertMessageInteropPayload(task.History[0], expectedText, kind)
+	assertTaskHistoryPayloads(task, []string{expectedText}, kind)
+}
+
+func assertTaskHistoryPayloads(task *a2a.Task, expectedTexts []string, kind string) {
+	gomega.Expect(task.History).To(gomega.HaveLen(len(expectedTexts)), kind)
+	for index, expectedText := range expectedTexts {
+		assertMessageInteropPayload(task.History[index], expectedText, kind)
+	}
 }
 
 func firstMessageText(message *a2a.Message) (string, error) {
@@ -480,8 +508,26 @@ func eventText(event a2a.Event) (string, bool, error) {
 	}
 }
 
+func firstArtifactText(artifact *a2a.Artifact) (string, error) {
+	if artifact == nil {
+		return "", errors.New("artifact was nil")
+	}
+
+	for _, part := range artifact.Parts {
+		if text := part.Text(); text != "" {
+			return text, nil
+		}
+	}
+
+	return "", errors.New("artifact did not include a text part")
+}
+
+func goClientSendResult(ctx context.Context, client *a2aclient.Client, text string, returnImmediately bool, taskID a2a.TaskID, contextID string) (a2a.SendMessageResult, error) {
+	return client.SendMessage(ctx, newInteropRequestWithIDs(text, returnImmediately, taskID, contextID))
+}
+
 func goClientSendTask(ctx context.Context, client *a2aclient.Client, text string, returnImmediately bool) (*a2a.Task, error) {
-	result, err := client.SendMessage(ctx, newInteropRequest(text, returnImmediately))
+	result, err := goClientSendResult(ctx, client, text, returnImmediately, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -492,6 +538,20 @@ func goClientSendTask(ctx context.Context, client *a2aclient.Client, text string
 	}
 
 	return task, nil
+}
+
+func goClientSendMessage(ctx context.Context, client *a2aclient.Client, text string) (*a2a.Message, error) {
+	result, err := goClientSendResult(ctx, client, text, false, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	message, ok := result.(*a2a.Message)
+	if !ok {
+		return nil, fmt.Errorf("unexpected unary response type %T", result)
+	}
+
+	return message, nil
 }
 
 func goClientUnaryText(ctx context.Context, client *a2aclient.Client) (string, error) {
@@ -582,6 +642,141 @@ func goClientAssertLifecycle(ctx context.Context, client *a2aclient.Client, serv
 
 	_, err = client.CancelTask(ctx, &a2a.CancelTaskRequest{ID: completedTask.ID})
 	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("cancel")))
+}
+
+func goClientWaitForTaskState(ctx context.Context, client *a2aclient.Client, taskID a2a.TaskID, expectedState a2a.TaskState) *a2a.Task {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		task, err := client.GetTask(ctx, &a2a.GetTaskRequest{ID: taskID})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if task.Status.State == expectedState {
+			return task
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	ginkgo.Fail(fmt.Sprintf("timed out waiting for task %s to reach state %s", taskID, expectedState))
+	return nil
+}
+
+func assertDataTypesTask(task *a2a.Task, kind string) {
+	gomega.Expect(task.Artifacts).To(gomega.HaveLen(1), kind)
+	artifact := task.Artifacts[0]
+	gomega.Expect(artifact.Parts).To(gomega.HaveLen(3), kind)
+	gomega.Expect(artifact.Parts[0].Text()).To(gomega.Equal("structured summary"), kind)
+	dataPart, ok := artifact.Parts[1].Data().(map[string]any)
+	gomega.Expect(ok).To(gomega.BeTrue(), kind)
+	gomega.Expect(dataPart).To(gomega.HaveKeyWithValue("kind", "report"), kind)
+	gomega.Expect(dataPart).To(gomega.HaveKeyWithValue("items", float64(2)), kind)
+	gomega.Expect(string(artifact.Parts[2].URL())).To(gomega.Equal("https://example.invalid/diagram.svg"), kind)
+	gomega.Expect(artifact.Parts[2].MediaType).To(gomega.Equal("image/svg+xml"), kind)
+}
+
+func assertExtendedCardMetadata(card *a2a.AgentCard, kind string) {
+	gomega.Expect(card).NotTo(gomega.BeNil(), kind)
+	gomega.Expect(card.Capabilities.ExtendedAgentCard).To(gomega.BeTrue(), kind)
+	gomega.Expect(card.Description).To(gomega.ContainSubstring("(extended)"), kind)
+
+	scheme, ok := card.SecuritySchemes[extendedCardSchemeID]
+	gomega.Expect(ok).To(gomega.BeTrue(), kind)
+	httpScheme, ok := scheme.(a2a.HTTPAuthSecurityScheme)
+	gomega.Expect(ok).To(gomega.BeTrue(), kind)
+	gomega.Expect(httpScheme.Scheme).To(gomega.Equal("Bearer"), kind)
+
+	for _, expectedSkill := range expectedSkillIDs {
+		gomega.Expect(card.Skills).To(gomega.ContainElement(gomega.HaveField("ID", expectedSkill)), kind)
+	}
+}
+
+func goClientAssertScenarioParity(ctx context.Context, client *a2aclient.Client, serverPrefix string) {
+	messageOnly, err := goClientSendMessage(ctx, client, messageOnlyRequestText)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	messageText, err := firstMessageText(messageOnly)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(messageText).To(gomega.Equal(fmt.Sprintf("%s server message-only response", serverPrefix)))
+
+	failedTask, err := goClientSendTask(ctx, client, taskFailureRequestText, false)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(failedTask.Status.State).To(gomega.Equal(a2a.TaskStateFailed))
+	failedText, err := taskStatusText(failedTask)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(failedText).To(gomega.Equal(fmt.Sprintf("%s server failed task", serverPrefix)))
+
+	inputRequiredTask, err := goClientSendTask(ctx, client, multiTurnStartRequestText, false)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(inputRequiredTask.Status.State).To(gomega.Equal(a2a.TaskStateInputRequired))
+	inputRequiredText, err := taskStatusText(inputRequiredTask)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(inputRequiredText).To(gomega.Equal(fmt.Sprintf("%s server needs more input", serverPrefix)))
+	assertTaskHistoryPayload(inputRequiredTask, multiTurnStartRequestText, "multi-turn start")
+
+	continuedResult, err := goClientSendResult(ctx, client, multiTurnContinueRequestText, false, inputRequiredTask.ID, inputRequiredTask.ContextID)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	continuedTask, ok := continuedResult.(*a2a.Task)
+	gomega.Expect(ok).To(gomega.BeTrue())
+	gomega.Expect(continuedTask.Status.State).To(gomega.Equal(a2a.TaskStateCompleted))
+	continuedText, err := taskStatusText(continuedTask)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(continuedText).To(gomega.Equal(fmt.Sprintf("%s server multi-turn completed", serverPrefix)))
+	assertTaskHistoryPayloads(continuedTask, []string{multiTurnStartRequestText, multiTurnContinueRequestText}, "multi-turn continuation")
+
+	streamingChunks := []string{}
+	sawStreamingStart := false
+	sawStreamingComplete := false
+	sawAppend := false
+	for event, err := range client.SendStreamingMessage(ctx, newInteropRequest(streamingRequestText, false)) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		switch value := event.(type) {
+		case *a2a.Task:
+			sawStreamingStart = true
+			gomega.Expect(value.Status.State).To(gomega.Equal(a2a.TaskStateWorking))
+			text, textErr := taskStatusText(value)
+			gomega.Expect(textErr).NotTo(gomega.HaveOccurred())
+			gomega.Expect(text).To(gomega.Equal(fmt.Sprintf("%s server streaming started", serverPrefix)))
+		case *a2a.TaskArtifactUpdateEvent:
+			text, textErr := firstArtifactText(value.Artifact)
+			gomega.Expect(textErr).NotTo(gomega.HaveOccurred())
+			streamingChunks = append(streamingChunks, text)
+			if value.Append {
+				sawAppend = true
+			}
+		case *a2a.TaskStatusUpdateEvent:
+			sawStreamingComplete = true
+			gomega.Expect(value.Status.State).To(gomega.Equal(a2a.TaskStateCompleted))
+			text, textErr := firstMessageText(value.Status.Message)
+			gomega.Expect(textErr).NotTo(gomega.HaveOccurred())
+			gomega.Expect(text).To(gomega.Equal(fmt.Sprintf("%s server streaming complete", serverPrefix)))
+		default:
+			ginkgo.Fail(fmt.Sprintf("unexpected streaming scenario event type %T", event))
+		}
+	}
+	gomega.Expect(sawStreamingStart).To(gomega.BeTrue())
+	gomega.Expect(sawStreamingComplete).To(gomega.BeTrue())
+	gomega.Expect(sawAppend).To(gomega.BeTrue())
+	gomega.Expect(streamingChunks).To(gomega.Equal([]string{"streaming chunk 1", "streaming chunk 2"}))
+
+	longRunningTask, err := goClientSendTask(ctx, client, longRunningRequestText, true)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(longRunningTask.Status.State).To(gomega.Equal(a2a.TaskStateWorking))
+	longRunningText, err := taskStatusText(longRunningTask)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(longRunningText).To(gomega.Equal(fmt.Sprintf("%s server long-running started", serverPrefix)))
+	longRunningCompleted := goClientWaitForTaskState(ctx, client, longRunningTask.ID, a2a.TaskStateCompleted)
+	longRunningCompletedText, err := taskStatusText(longRunningCompleted)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(longRunningCompletedText).To(gomega.Equal(fmt.Sprintf("%s server long-running complete", serverPrefix)))
+
+	dataTypesTask, err := goClientSendTask(ctx, client, dataTypesRequestText, false)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(dataTypesTask.Status.State).To(gomega.Equal(a2a.TaskStateCompleted))
+	dataTypesText, err := taskStatusText(dataTypesTask)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(dataTypesText).To(gomega.Equal(fmt.Sprintf("%s server data-types ready", serverPrefix)))
+	assertDataTypesTask(dataTypesTask, "data-types")
+
+	extendedCard, err := client.GetExtendedAgentCard(ctx, &a2a.GetExtendedAgentCardRequest{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	assertExtendedCardMetadata(extendedCard, "extended-card")
 }
 
 func runRustProbe(
@@ -711,6 +906,7 @@ var _ = ginkgo.Describe("A2A Rust and Go interoperability", ginkgo.Ordered, gink
 			gomega.Expect(streamText).To(gomega.Equal(expectedServerText("go", requestText)))
 
 			goClientAssertLifecycle(requestCtx, client, "go", true)
+			goClientAssertScenarioParity(requestCtx, client, "go")
 		})
 
 		ginkgo.It("lets the Go client call the Rust fixture", ginkgo.Label("jsonrpc", "go-rust"), func(ctx ginkgo.SpecContext) {
@@ -729,6 +925,7 @@ var _ = ginkgo.Describe("A2A Rust and Go interoperability", ginkgo.Ordered, gink
 			gomega.Expect(streamText).To(gomega.Equal(expectedServerText("rust", requestText)))
 
 			goClientAssertLifecycle(requestCtx, client, "rust", true)
+			goClientAssertScenarioParity(requestCtx, client, "rust")
 		})
 
 		ginkgo.It("lets the Rust client call the Go fixture", ginkgo.Label("jsonrpc", "rust-go"), func(ctx ginkgo.SpecContext) {
@@ -769,6 +966,7 @@ var _ = ginkgo.Describe("A2A Rust and Go interoperability", ginkgo.Ordered, gink
 			gomega.Expect(streamText).To(gomega.Equal(expectedServerText("go", requestText)))
 
 			goClientAssertLifecycle(requestCtx, client, "go", true)
+			goClientAssertScenarioParity(requestCtx, client, "go")
 		})
 
 		ginkgo.It("lets the Go client call the Rust fixture over REST", ginkgo.Label("rest", "go-rust"), func(ctx ginkgo.SpecContext) {
@@ -787,6 +985,7 @@ var _ = ginkgo.Describe("A2A Rust and Go interoperability", ginkgo.Ordered, gink
 			gomega.Expect(streamText).To(gomega.Equal(expectedServerText("rust", requestText)))
 
 			goClientAssertLifecycle(requestCtx, client, "rust", true)
+			goClientAssertScenarioParity(requestCtx, client, "rust")
 		})
 
 		ginkgo.It("lets the Rust client call the Go fixture over REST", ginkgo.Label("rest", "rust-go"), func(ctx ginkgo.SpecContext) {
@@ -827,6 +1026,7 @@ var _ = ginkgo.Describe("A2A Rust and Go interoperability", ginkgo.Ordered, gink
 			gomega.Expect(streamText).To(gomega.Equal(expectedServerText("go", requestText)))
 
 			goClientAssertLifecycle(requestCtx, client, "go", true)
+			goClientAssertScenarioParity(requestCtx, client, "go")
 		})
 
 		ginkgo.It("lets the Go client call the Rust fixture over gRPC", ginkgo.Label("grpc", "go-rust"), func(ctx ginkgo.SpecContext) {
@@ -845,6 +1045,7 @@ var _ = ginkgo.Describe("A2A Rust and Go interoperability", ginkgo.Ordered, gink
 			gomega.Expect(streamText).To(gomega.Equal(expectedServerText("rust", requestText)))
 
 			goClientAssertLifecycle(requestCtx, client, "rust", true)
+			goClientAssertScenarioParity(requestCtx, client, "rust")
 		})
 
 		ginkgo.It("lets the Rust client call the Go fixture over gRPC", ginkgo.Label("grpc", "rust-go"), func(ctx ginkgo.SpecContext) {


### PR DESCRIPTION
## Summary
- expand the CSIT-owned Rust, Go, and .NET A2A fixtures to cover message-only, failed-task, multi-turn, streaming, long-running, data-types, and extended-card scenarios
- extend the Rust and .NET probes plus the Go-client interoperability assertions so the existing interop matrix validates that richer scenario slice across the supported transports
- update the A2A integration README to describe the widened coverage and document the temporary omission of .NET securitySchemes metadata for Rust resolver compatibility

## Testing
- cd integrations/agntcy-a2a && task test
