### PR TITLE
feat(agntcy-a2a): add python interop coverage

### DIFF
--- a/.github/workflows/test-integrations.yaml
+++ b/.github/workflows/test-integrations.yaml
@@ -258,14 +258,32 @@ jobs:
       matrix:
         include:
           # Add one entry per SDK pair. Each row runs as its own parallel job.
-          # Future pairs should follow the same shape, for example rust-javascript,
-          # rust-java, or rust-python with the task and runtime setup they require.
+          # Future pairs should follow the same shape, including the task and
+          # runtime setup required for that SDK combination.
           - id: rust-go
             display-name: Rust/Go
             task: integrations:a2a:test:rust-go
             artifact-name: a2a-interop-test-result-rust-go
             setup-python: 'false'
             setup-go: 'true'
+            go-version: '1.24.4'
+            setup-dotnet: 'false'
+            dotnet-version: '8.0.x'
+          - id: python-go
+            display-name: Python/Go
+            task: integrations:a2a:test:python-go
+            artifact-name: a2a-interop-test-result-python-go
+            setup-python: 'true'
+            setup-go: 'true'
+            go-version: '1.24.4'
+            setup-dotnet: 'false'
+            dotnet-version: '8.0.x'
+          - id: rust-python
+            display-name: Rust/Python
+            task: integrations:a2a:test:rust-python
+            artifact-name: a2a-interop-test-result-rust-python
+            setup-python: 'true'
+            setup-go: 'false'
             go-version: '1.24.4'
             setup-dotnet: 'false'
             dotnet-version: '8.0.x'

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ task: Available tasks for this project:
 * benchmarks:directory:test:                              All ADS benchmark test
 * benchmarks:slim:test:                                All Slim benchmark test
 * integrations:a2a:test:                                 All A2A interoperability tests
+* integrations:a2a:test:python-go:                       Python and Go interoperability tests
+* integrations:a2a:test:rust-python:                     Rust and Python interoperability tests
 * integrations:a2a:test:rust-go:jsonrpc:                 Rust and Go JSON-RPC interoperability smoke test
 * integrations:a2a:test:rust-go:jsonrpc:go-go:           Go client to Go server JSON-RPC interoperability test
 * integrations:a2a:test:rust-go:jsonrpc:go-rust:         Go client to Rust server JSON-RPC interoperability test
@@ -180,26 +182,27 @@ task integratons:kind:destroy
 
 The `integrations/agntcy-a2a` suite is self-contained and does not require a
 Kind cluster, Helm, or repository sibling checkouts. It builds and runs small
-Go and Rust JSON-RPC fixtures locally to exercise this matrix:
+Go, Rust, .NET, and Python fixtures locally across these suite slices:
 
-- Go client -> Go server
-- Go client -> Rust server
-- Rust client -> Go server
-- Rust client -> Rust server
+- Rust/Go across JSON-RPC, HTTP+JSON, and gRPC
+- Rust/.NET across JSON-RPC and HTTP+JSON
+- Python/Go across JSON-RPC and HTTP+JSON
+- Rust/Python across JSON-RPC and HTTP+JSON
 
 To run it from the repository root you need:
 
 - [Taskfile](https://taskfile.dev/installation/)
-- [Go](https://go.dev/doc/install)
 - [Rust and Cargo](https://www.rust-lang.org/tools/install)
+- [Go](https://go.dev/doc/install) for the Rust/Go and Python/Go slices
+- Python 3.10+ for the Python/Go and Rust/Python slices
+- .NET 8 SDK for the Rust/.NET slice
 
 ```bash
 task integrations:a2a:test
 task integrations:a2a:test:rust-go:jsonrpc
-task integrations:a2a:test:rust-go:jsonrpc:go-go
-task integrations:a2a:test:rust-go:jsonrpc:go-rust
-task integrations:a2a:test:rust-go:jsonrpc:rust-go
-task integrations:a2a:test:rust-go:jsonrpc:rust-rust
+task integrations:a2a:test:python-go
+task integrations:a2a:test:rust-python
+task integrations:a2a:test:rust-python:jsonrpc:python-rust
 ```
 
 The suite writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`.

--- a/integrations/agntcy-a2a/README.md
+++ b/integrations/agntcy-a2a/README.md
@@ -4,7 +4,7 @@ This component hosts cross-SDK A2A interoperability checks.
 
 The suite is structured around shared Ginkgo behaviors and per-SDK harnesses. The behavior assertions are written once, expanded across client/server transport matrices, and the language-specific differences are isolated behind Go, Rust, .NET, and Python launchers or probes.
 
-The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC, a Rust/.NET suite across JSON-RPC and HTTP+JSON, and a Python v1.0/Go suite across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
+The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC, a Rust/.NET suite across JSON-RPC and HTTP+JSON, and Python v1.0 suites for both Go and Rust across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
 
 All 12 Rust/Go client-server legs are green across JSON-RPC, HTTP+JSON, and gRPC. The Go and Rust fixtures expose push-config CRUD, and CSIT validates that path from both clients against both server targets across all three transports.
 
@@ -12,7 +12,9 @@ The Rust/.NET suite reuses the existing Rust fixture and Rust probe, adds CSIT-o
 
 The Python/Go suite adds a CSIT-owned Python server and probe built against the `release-please--branches--1.0-dev` branch of `a2aproject/a2a-python`. It currently covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
-Push-config is covered in the Rust/.NET suite as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. The default `task test` and `task integrations:a2a:test` entrypoints run the Rust/Go, Rust/.NET, and Python/Go suites.
+The Rust/Python suite reuses the existing Rust fixture and probe together with the same CSIT-owned Python server and probe. It currently covers 8 legs: 4 JSON-RPC legs (`rust-rust`, `rust-python`, `python-rust`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+
+Push-config is covered in the Rust/.NET suite as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. The default `task test` and `task integrations:a2a:test` entrypoints run the Rust/Go, Rust/.NET, Python/Go, and Rust/Python suites.
 
 Across the matrix, the scenarios validate the same core interoperability behavior:
 
@@ -26,7 +28,7 @@ Across the matrix, the scenarios validate the same core interoperability behavio
 - structured text + data + URL artifact payloads
 - extended-agent-card discovery and skill metadata
 - negative-path error semantics for missing and non-cancelable tasks
-- successful push-config CRUD on both server paths across all three transports
+- successful push-config CRUD on supported server paths across the covered transports
 - preservation of a mixed text plus structured-data request payload and message metadata through task history
 
 The fixtures are intentionally small and deterministic so the suite can run the same way locally and in CI without depending on sibling SDK checkouts.
@@ -37,7 +39,7 @@ The gRPC legs follow the same agent-card discovery path as the other transports:
 
 The Rust/.NET slice currently requires a local `dotnet` CLI for the .NET 8 SDK because the CSIT harness builds the fixture and probe from published `A2A` and `A2A.AspNetCore` NuGet packages at test time.
 
-The Python/Go slice requires Python 3.10+ and installs the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `release-please--branches--1.0-dev` branch.
+The Python/Go and Rust/Python slices require Python 3.10+ and install the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `release-please--branches--1.0-dev` branch.
 
 ## Matrix
 
@@ -50,6 +52,7 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | Rust/Go | ✅ | ✅ | ✅ |
 | Rust/.NET | ✅ | ✅ | ❌ |
 | Python/Go | ✅ | ✅ | ❌ |
+| Rust/Python | ✅ | ✅ | ❌ |
 
 ### Rust/Go Leg Coverage
 
@@ -78,26 +81,35 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | Python -> Go | ✅ | ✅ | ❌ |
 | Python -> Python | ✅ | ✅ | ❌ |
 
+### Rust/Python Leg Coverage
+
+| Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
+| --- | --- | --- | --- |
+| Rust -> Rust (Rust/Python slice) | ✅ | ✅ | ❌ |
+| Rust -> Python | ✅ | ✅ | ❌ |
+| Python -> Rust | ✅ | ✅ | ❌ |
+| Python -> Python (Rust/Python slice) | ✅ | ✅ | ❌ |
+
 ### Behavior Coverage
 
-| Behavior | Rust/Go | Rust/.NET | Python/Go |
-| --- | --- | --- | --- |
-| Unary `SendMessage` | ✅ | ✅ | ✅ |
-| Streaming `SendMessage` | ✅ | ✅ | ✅ |
-| Message-only response path | ✅ | ✅ | ✅ |
-| `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ | ✅ |
-| Failed-task response path | ✅ | ✅ | ✅ |
-| Multi-turn input-required continuation | ✅ | ✅ | ✅ |
-| Long-running completion after non-blocking send | ✅ | ✅ | ✅ |
-| Artifact-rich streaming updates | ✅ | ✅ | ✅ |
-| Structured text + data + URL artifact payloads | ✅ | ✅ | ✅ |
-| Extended-agent-card discovery | ✅ | ✅ | ✅ |
-| Extended-card security-scheme metadata | ✅ | ✅ | ✅ |
-| Missing-task and non-cancelable-task errors | ✅ | ✅ | ✅ |
-| Mixed text + structured-data payload preserved through task history | ✅ | ✅ | ✅ |
-| Push-config CRUD against Rust-server targets | ✅ | ✅ | n/a |
-| Unsupported push-config response against non-Rust server targets | ✅ | ✅ | n/a |
-| Push-config CRUD against Go- and Python-server targets | n/a | n/a | ✅ |
+| Behavior | Rust/Go | Rust/.NET | Python/Go | Rust/Python |
+| --- | --- | --- | --- | --- |
+| Unary `SendMessage` | ✅ | ✅ | ✅ | ✅ |
+| Streaming `SendMessage` | ✅ | ✅ | ✅ | ✅ |
+| Message-only response path | ✅ | ✅ | ✅ | ✅ |
+| `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ | ✅ | ✅ |
+| Failed-task response path | ✅ | ✅ | ✅ | ✅ |
+| Multi-turn input-required continuation | ✅ | ✅ | ✅ | ✅ |
+| Long-running completion after non-blocking send | ✅ | ✅ | ✅ | ✅ |
+| Artifact-rich streaming updates | ✅ | ✅ | ✅ | ✅ |
+| Structured text + data + URL artifact payloads | ✅ | ✅ | ✅ | ✅ |
+| Extended-agent-card discovery | ✅ | ✅ | ✅ | ✅ |
+| Extended-card security-scheme metadata | ✅ | ✅ | ✅ | ✅ |
+| Missing-task and non-cancelable-task errors | ✅ | ✅ | ✅ | ✅ |
+| Mixed text + structured-data payload preserved through task history | ✅ | ✅ | ✅ | ✅ |
+| Push-config CRUD against Rust-server targets | ✅ | ✅ | n/a | ✅ |
+| Unsupported push-config response against non-Rust server targets | ✅ | ✅ | n/a | n/a |
+| Push-config CRUD against Go- and Python-server targets where covered | n/a | n/a | ✅ | ✅ |
 
 For Rust/.NET, the uncovered cells are the current gRPC gap. For push-config, a ✅ means the suite verifies the expected behavior for that leg: CRUD succeeds on Rust-server targets and the current unsupported error is returned on Go-server or .NET-server targets.
 
@@ -112,9 +124,10 @@ task test
 task test:rust-go
 task test:rust-dotnet
 task test:python-go
+task test:rust-python
 ```
 
-`task test` now runs the full `task test:rust-go` transport matrix plus `task test:rust-dotnet` and `task test:python-go`.
+`task test` now runs the full `task test:rust-go` transport matrix plus `task test:rust-dotnet`, `task test:python-go`, and `task test:rust-python`.
 
 The user-facing task triggers are organized by scope:
 
@@ -125,6 +138,7 @@ task test
 task test:rust-go
 task test:rust-dotnet
 task test:python-go
+task test:rust-python
 ```
 
 - Cross-suite behavior slices:
@@ -202,6 +216,26 @@ task test:python-go:behavior:push-config
 task test:python-go:behavior:parity
 ```
 
+- Rust/Python suite filters:
+
+```sh
+task test:rust-python:jsonrpc
+task test:rust-python:rest
+task test:rust-python:jsonrpc:rust-rust
+task test:rust-python:jsonrpc:rust-python
+task test:rust-python:jsonrpc:python-rust
+task test:rust-python:jsonrpc:python-python
+task test:rust-python:rest:rust-rust
+task test:rust-python:rest:rust-python
+task test:rust-python:rest:python-rust
+task test:rust-python:rest:python-python
+task test:rust-python:behavior:core
+task test:rust-python:behavior:unary-streaming
+task test:rust-python:behavior:lifecycle
+task test:rust-python:behavior:push-config
+task test:rust-python:behavior:parity
+```
+
 The canonical Rust/.NET pair trigger is `rust-rust-dotnet`. The shorter `rust-rust` name is still kept as a compatibility alias in the Taskfile, but new usage should prefer `rust-rust-dotnet`.
 
 From the repository root, prepend `integrations:a2a:` to any component-level task trigger:
@@ -213,9 +247,10 @@ task integrations:a2a:test:rust-dotnet:jsonrpc:rust-rust-dotnet
 task integrations:a2a:test:rust-go:behavior:lifecycle
 task integrations:a2a:test:rust-dotnet:behavior:parity
 task integrations:a2a:test:python-go:rest:python-python
+task integrations:a2a:test:rust-python:jsonrpc:python-rust
 ```
 
-Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, and the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, and `report-agntcy-a2a-python-go-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
+Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`, and the combined Rust/Python suite emits `report-agntcy-a2a-rust-python.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, `report-agntcy-a2a-python-go-rest.{json,xml}`, `report-agntcy-a2a-rust-python-jsonrpc.{json,xml}`, and `report-agntcy-a2a-rust-python-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
 
 ## How to Add a Test
 
@@ -248,4 +283,4 @@ To add a new shared behavior:
 	`fixtures/python/interop_python_probe.py`
 5. Run the narrowest task that exercises the new behavior first, for example `task test:rust-go:behavior:lifecycle` or `task test:behavior:lifecycle`, then run the broader suite once that path is green.
 
-If you are adding a new leg rather than a new behavior, use the Rust/Go suite wrapper in `tests/interop_rust_go_test.go` or the Python/Go suite wrapper in `tests/interop_python_go_test.go` as the model. Update the `clients` or `servers` tables there and let `registerInteropTransportMatrix(...)` expand the existing shared behaviors over the new matrix entry. Keep wrapper-level customization limited to matrix declarations and pair-specific overrides, as shown in `tests/interop_rust_dotnet_test.go` for the Rust/.NET push-config expectations.
+If you are adding a new leg rather than a new behavior, use the Rust/Go suite wrapper in `tests/interop_rust_go_test.go`, the Python/Go suite wrapper in `tests/interop_python_go_test.go`, or the Rust/Python suite wrapper in `tests/interop_rust_python_test.go` as the model. Update the `clients` or `servers` tables there and let `registerInteropTransportMatrix(...)` expand the existing shared behaviors over the new matrix entry. Keep wrapper-level customization limited to matrix declarations and pair-specific overrides, as shown in `tests/interop_rust_dotnet_test.go` for the Rust/.NET push-config expectations.

--- a/integrations/agntcy-a2a/README.md
+++ b/integrations/agntcy-a2a/README.md
@@ -2,15 +2,17 @@
 
 This component hosts cross-SDK A2A interoperability checks.
 
-The suite is structured around shared Ginkgo behaviors and per-SDK harnesses. The behavior assertions are written once, expanded across client/server transport matrices, and the language-specific differences are isolated behind Go, Rust, and .NET launchers or probes.
+The suite is structured around shared Ginkgo behaviors and per-SDK harnesses. The behavior assertions are written once, expanded across client/server transport matrices, and the language-specific differences are isolated behind Go, Rust, .NET, and Python launchers or probes.
 
-The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC plus a Rust/.NET suite across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
+The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC, a Rust/.NET suite across JSON-RPC and HTTP+JSON, and a Python v1.0/Go suite across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
 
 All 12 Rust/Go client-server legs are green across JSON-RPC, HTTP+JSON, and gRPC. The Go and Rust fixtures expose push-config CRUD, and CSIT validates that path from both clients against both server targets across all three transports.
 
 The Rust/.NET suite reuses the existing Rust fixture and Rust probe, adds CSIT-owned .NET fixture and probe binaries, and covers 8 legs: 4 JSON-RPC legs (`dotnet-dotnet`, `dotnet-rust`, `rust-dotnet`, `rust-rust-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
-Push-config is covered in the Rust/.NET suite as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. The default `task test` and `task integrations:a2a:test` entrypoints run both the Rust/Go and Rust/.NET suites.
+The Python/Go suite adds a CSIT-owned Python server and probe built against the `release-please--branches--1.0-dev` branch of `a2aproject/a2a-python`. It currently covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+
+Push-config is covered in the Rust/.NET suite as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. The default `task test` and `task integrations:a2a:test` entrypoints run the Rust/Go, Rust/.NET, and Python/Go suites.
 
 Across the matrix, the scenarios validate the same core interoperability behavior:
 
@@ -35,6 +37,8 @@ The gRPC legs follow the same agent-card discovery path as the other transports:
 
 The Rust/.NET slice currently requires a local `dotnet` CLI for the .NET 8 SDK because the CSIT harness builds the fixture and probe from published `A2A` and `A2A.AspNetCore` NuGet packages at test time.
 
+The Python/Go slice requires Python 3.10+ and installs the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `release-please--branches--1.0-dev` branch.
+
 ## Matrix
 
 Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this suite.
@@ -45,6 +49,7 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | --- | --- | --- | --- |
 | Rust/Go | ✅ | ✅ | ✅ |
 | Rust/.NET | ✅ | ✅ | ❌ |
+| Python/Go | ✅ | ✅ | ❌ |
 
 ### Rust/Go Leg Coverage
 
@@ -64,25 +69,35 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | Rust -> .NET | ✅ | ✅ | ❌ |
 | Rust -> Rust (Rust/.NET slice) | ✅ | ✅ | ❌ |
 
+### Python/Go Leg Coverage
+
+| Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
+| --- | --- | --- | --- |
+| Go -> Go (Python/Go slice) | ✅ | ✅ | ❌ |
+| Go -> Python | ✅ | ✅ | ❌ |
+| Python -> Go | ✅ | ✅ | ❌ |
+| Python -> Python | ✅ | ✅ | ❌ |
+
 ### Behavior Coverage
 
-| Behavior | Rust/Go | Rust/.NET |
-| --- | --- | --- |
-| Unary `SendMessage` | ✅ | ✅ |
-| Streaming `SendMessage` | ✅ | ✅ |
-| Message-only response path | ✅ | ✅ |
-| `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ |
-| Failed-task response path | ✅ | ✅ |
-| Multi-turn input-required continuation | ✅ | ✅ |
-| Long-running completion after non-blocking send | ✅ | ✅ |
-| Artifact-rich streaming updates | ✅ | ✅ |
-| Structured text + data + URL artifact payloads | ✅ | ✅ |
-| Extended-agent-card discovery | ✅ | ✅ |
-| Extended-card security-scheme metadata | ✅ | ✅ |
-| Missing-task and non-cancelable-task errors | ✅ | ✅ |
-| Mixed text + structured-data payload preserved through task history | ✅ | ✅ |
-| Push-config CRUD against Rust-server targets | ✅ | ✅ |
-| Unsupported push-config response against non-Rust server targets | ✅ | ✅ |
+| Behavior | Rust/Go | Rust/.NET | Python/Go |
+| --- | --- | --- | --- |
+| Unary `SendMessage` | ✅ | ✅ | ✅ |
+| Streaming `SendMessage` | ✅ | ✅ | ✅ |
+| Message-only response path | ✅ | ✅ | ✅ |
+| `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ | ✅ |
+| Failed-task response path | ✅ | ✅ | ✅ |
+| Multi-turn input-required continuation | ✅ | ✅ | ✅ |
+| Long-running completion after non-blocking send | ✅ | ✅ | ✅ |
+| Artifact-rich streaming updates | ✅ | ✅ | ✅ |
+| Structured text + data + URL artifact payloads | ✅ | ✅ | ✅ |
+| Extended-agent-card discovery | ✅ | ✅ | ✅ |
+| Extended-card security-scheme metadata | ✅ | ✅ | ✅ |
+| Missing-task and non-cancelable-task errors | ✅ | ✅ | ✅ |
+| Mixed text + structured-data payload preserved through task history | ✅ | ✅ | ✅ |
+| Push-config CRUD against Rust-server targets | ✅ | ✅ | n/a |
+| Unsupported push-config response against non-Rust server targets | ✅ | ✅ | n/a |
+| Push-config CRUD against Go- and Python-server targets | n/a | n/a | ✅ |
 
 For Rust/.NET, the uncovered cells are the current gRPC gap. For push-config, a ✅ means the suite verifies the expected behavior for that leg: CRUD succeeds on Rust-server targets and the current unsupported error is returned on Go-server or .NET-server targets.
 
@@ -96,9 +111,10 @@ From `integrations/agntcy-a2a/`:
 task test
 task test:rust-go
 task test:rust-dotnet
+task test:python-go
 ```
 
-`task test` now runs the full `task test:rust-go` transport matrix plus `task test:rust-dotnet`.
+`task test` now runs the full `task test:rust-go` transport matrix plus `task test:rust-dotnet` and `task test:python-go`.
 
 The user-facing task triggers are organized by scope:
 
@@ -108,6 +124,7 @@ The user-facing task triggers are organized by scope:
 task test
 task test:rust-go
 task test:rust-dotnet
+task test:python-go
 ```
 
 - Cross-suite behavior slices:
@@ -165,6 +182,26 @@ task test:rust-dotnet:behavior:push-config
 task test:rust-dotnet:behavior:parity
 ```
 
+- Python/Go suite filters:
+
+```sh
+task test:python-go:jsonrpc
+task test:python-go:rest
+task test:python-go:jsonrpc:go-go
+task test:python-go:jsonrpc:go-python
+task test:python-go:jsonrpc:python-go
+task test:python-go:jsonrpc:python-python
+task test:python-go:rest:go-go
+task test:python-go:rest:go-python
+task test:python-go:rest:python-go
+task test:python-go:rest:python-python
+task test:python-go:behavior:core
+task test:python-go:behavior:unary-streaming
+task test:python-go:behavior:lifecycle
+task test:python-go:behavior:push-config
+task test:python-go:behavior:parity
+```
+
 The canonical Rust/.NET pair trigger is `rust-rust-dotnet`. The shorter `rust-rust` name is still kept as a compatibility alias in the Taskfile, but new usage should prefer `rust-rust-dotnet`.
 
 From the repository root, prepend `integrations:a2a:` to any component-level task trigger:
@@ -175,9 +212,10 @@ task integrations:a2a:test:rust-go:grpc:rust-rust
 task integrations:a2a:test:rust-dotnet:jsonrpc:rust-rust-dotnet
 task integrations:a2a:test:rust-go:behavior:lifecycle
 task integrations:a2a:test:rust-dotnet:behavior:parity
+task integrations:a2a:test:python-go:rest:python-python
 ```
 
-Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, the transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, and `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
+Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, and the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, and `report-agntcy-a2a-python-go-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
 
 ## How to Add a Test
 
@@ -202,11 +240,12 @@ That one behavior entry is expanded into multiple specs because the suite wrappe
 To add a new shared behavior:
 
 1. Add a new method to `interopHarness` in `tests/interop_behaviors_test.go`.
-2. Implement that method in each harness that should participate, such as `goSDKHarness`, `rustProbeHarness`, and `dotNetProbeHarness`.
+2. Implement that method in each harness that should participate, such as `goSDKHarness`, `rustProbeHarness`, `dotNetProbeHarness`, and `pythonProbeHarness`.
 3. Add a new entry to `sharedInteropBehaviorSpecs` with a stable label. If the behavior should be runnable as a first-class filtered target like the current behavior slices, add matching Taskfile targets and document them here.
-4. If the Rust or .NET harnesses need their own focused scenario selection, add a new `probeScenario` in `tests/interop_shared_test.go`, pass it through `tests/interop_launchers_test.go`, and implement the scenario in the matching probe binary:
+4. If the Rust, .NET, or Python harnesses need their own focused scenario selection, add a new `probeScenario` in `tests/interop_shared_test.go`, pass it through `tests/interop_launchers_test.go`, and implement the scenario in the matching probe binary:
    `fixtures/rust/src/bin/interop-rust-probe.rs`
    `fixtures/dotnet/InteropProbe/Program.cs`
+	`fixtures/python/interop_python_probe.py`
 5. Run the narrowest task that exercises the new behavior first, for example `task test:rust-go:behavior:lifecycle` or `task test:behavior:lifecycle`, then run the broader suite once that path is green.
 
-If you are adding a new leg rather than a new behavior, use the Rust/Go suite wrapper in `tests/interop_rust_go_test.go` as the model. Update the `clients` or `servers` tables there and let `registerInteropTransportMatrix(...)` expand the existing shared behaviors over the new matrix entry. Keep wrapper-level customization limited to matrix declarations and pair-specific overrides, as shown in `tests/interop_rust_dotnet_test.go` for the Rust/.NET push-config expectations.
+If you are adding a new leg rather than a new behavior, use the Rust/Go suite wrapper in `tests/interop_rust_go_test.go` or the Python/Go suite wrapper in `tests/interop_python_go_test.go` as the model. Update the `clients` or `servers` tables there and let `registerInteropTransportMatrix(...)` expand the existing shared behaviors over the new matrix entry. Keep wrapper-level customization limited to matrix declarations and pair-specific overrides, as shown in `tests/interop_rust_dotnet_test.go` for the Rust/.NET push-config expectations.

--- a/integrations/agntcy-a2a/Taskfile.yml
+++ b/integrations/agntcy-a2a/Taskfile.yml
@@ -12,6 +12,7 @@ tasks:
     cmds:
       - task: test:rust-go
       - task: test:rust-dotnet
+      - task: test:python-go
 
   test:rust-go:
     desc: Rust and Go interoperability test matrix across JSON-RPC, HTTP+JSON, and gRPC
@@ -28,6 +29,14 @@ tasks:
         vars:
           LABEL_FILTER: suite-rust-dotnet
           REPORT_NAME: report-agntcy-a2a-rust-dotnet
+
+  test:python-go:
+    desc: Python v1.0 and Go interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go
+          REPORT_NAME: report-agntcy-a2a-python-go
 
   test:behavior:core:
     desc: Shared core behavior slices across all A2A interoperability suites
@@ -149,6 +158,46 @@ tasks:
           LABEL_FILTER: suite-rust-dotnet && behavior-parity
           REPORT_NAME: report-agntcy-a2a-rust-dotnet-behavior-parity
 
+  test:python-go:behavior:core:
+    desc: Python and Go shared core behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && behavior-core
+          REPORT_NAME: report-agntcy-a2a-python-go-behavior-core
+
+  test:python-go:behavior:unary-streaming:
+    desc: Python and Go unary and streaming behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && behavior-unary-streaming
+          REPORT_NAME: report-agntcy-a2a-python-go-behavior-unary-streaming
+
+  test:python-go:behavior:lifecycle:
+    desc: Python and Go task lifecycle behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && behavior-lifecycle
+          REPORT_NAME: report-agntcy-a2a-python-go-behavior-lifecycle
+
+  test:python-go:behavior:push-config:
+    desc: Python and Go push-config behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && behavior-push-config
+          REPORT_NAME: report-agntcy-a2a-python-go-behavior-push-config
+
+  test:python-go:behavior:parity:
+    desc: Python and Go scenario parity behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && behavior-parity
+          REPORT_NAME: report-agntcy-a2a-python-go-behavior-parity
+
   test:rust-dotnet:jsonrpc:
     desc: Rust and .NET JSON-RPC interoperability matrix
     cmds:
@@ -238,6 +287,86 @@ tasks:
     desc: Alias for test:rust-dotnet:rest:rust-rust-dotnet
     cmds:
       - task: test:rust-dotnet:rest:rust-rust-dotnet
+
+  test:python-go:jsonrpc:
+    desc: Python and Go JSON-RPC interoperability matrix
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && jsonrpc
+          REPORT_NAME: report-agntcy-a2a-python-go-jsonrpc
+
+  test:python-go:jsonrpc:go-go:
+    desc: Go client to Go server JSON-RPC interoperability test for the Python/Go slice
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && jsonrpc && go-go
+          REPORT_NAME: report-agntcy-a2a-python-go-jsonrpc-go-go
+
+  test:python-go:jsonrpc:go-python:
+    desc: Go client to Python server JSON-RPC interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && jsonrpc && go-python
+          REPORT_NAME: report-agntcy-a2a-python-go-jsonrpc-go-python
+
+  test:python-go:jsonrpc:python-go:
+    desc: Python client to Go server JSON-RPC interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && jsonrpc && python-go
+          REPORT_NAME: report-agntcy-a2a-python-go-jsonrpc-python-go
+
+  test:python-go:jsonrpc:python-python:
+    desc: Python client to Python server JSON-RPC interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && jsonrpc && python-python
+          REPORT_NAME: report-agntcy-a2a-python-go-jsonrpc-python-python
+
+  test:python-go:rest:
+    desc: Python and Go HTTP+JSON interoperability matrix
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && rest
+          REPORT_NAME: report-agntcy-a2a-python-go-rest
+
+  test:python-go:rest:go-go:
+    desc: Go client to Go server HTTP+JSON interoperability test for the Python/Go slice
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && rest && go-go
+          REPORT_NAME: report-agntcy-a2a-python-go-rest-go-go
+
+  test:python-go:rest:go-python:
+    desc: Go client to Python server HTTP+JSON interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && rest && go-python
+          REPORT_NAME: report-agntcy-a2a-python-go-rest-go-python
+
+  test:python-go:rest:python-go:
+    desc: Python client to Go server HTTP+JSON interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && rest && python-go
+          REPORT_NAME: report-agntcy-a2a-python-go-rest-python-go
+
+  test:python-go:rest:python-python:
+    desc: Python client to Python server HTTP+JSON interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && rest && python-python
+          REPORT_NAME: report-agntcy-a2a-python-go-rest-python-python
 
   test:rust-go:jsonrpc:
     desc: Rust and Go JSON-RPC interoperability matrix
@@ -380,6 +509,14 @@ tasks:
           REPORT_NAME: '{{.REPORT_NAME}}'
 
   test:rust-dotnet:run:
+    internal: true
+    cmds:
+      - task: test:interop:run
+        vars:
+          LABEL_FILTER: '{{.LABEL_FILTER}}'
+          REPORT_NAME: '{{.REPORT_NAME}}'
+
+  test:python-go:run:
     internal: true
     cmds:
       - task: test:interop:run

--- a/integrations/agntcy-a2a/Taskfile.yml
+++ b/integrations/agntcy-a2a/Taskfile.yml
@@ -13,6 +13,7 @@ tasks:
       - task: test:rust-go
       - task: test:rust-dotnet
       - task: test:python-go
+      - task: test:rust-python
 
   test:rust-go:
     desc: Rust and Go interoperability test matrix across JSON-RPC, HTTP+JSON, and gRPC
@@ -37,6 +38,14 @@ tasks:
         vars:
           LABEL_FILTER: suite-python-go
           REPORT_NAME: report-agntcy-a2a-python-go
+
+  test:rust-python:
+    desc: Rust and Python v1.0 interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python
+          REPORT_NAME: report-agntcy-a2a-rust-python
 
   test:behavior:core:
     desc: Shared core behavior slices across all A2A interoperability suites
@@ -197,6 +206,46 @@ tasks:
         vars:
           LABEL_FILTER: suite-python-go && behavior-parity
           REPORT_NAME: report-agntcy-a2a-python-go-behavior-parity
+
+  test:rust-python:behavior:core:
+    desc: Rust and Python shared core behavior slices across all transports and pairs
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && behavior-core
+          REPORT_NAME: report-agntcy-a2a-rust-python-behavior-core
+
+  test:rust-python:behavior:unary-streaming:
+    desc: Rust and Python unary and streaming behavior slices across all transports and pairs
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && behavior-unary-streaming
+          REPORT_NAME: report-agntcy-a2a-rust-python-behavior-unary-streaming
+
+  test:rust-python:behavior:lifecycle:
+    desc: Rust and Python task lifecycle behavior slices across all transports and pairs
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && behavior-lifecycle
+          REPORT_NAME: report-agntcy-a2a-rust-python-behavior-lifecycle
+
+  test:rust-python:behavior:push-config:
+    desc: Rust and Python push-config behavior slices across all transports and pairs
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && behavior-push-config
+          REPORT_NAME: report-agntcy-a2a-rust-python-behavior-push-config
+
+  test:rust-python:behavior:parity:
+    desc: Rust and Python scenario parity behavior slices across all transports and pairs
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && behavior-parity
+          REPORT_NAME: report-agntcy-a2a-rust-python-behavior-parity
 
   test:rust-dotnet:jsonrpc:
     desc: Rust and .NET JSON-RPC interoperability matrix
@@ -368,6 +417,86 @@ tasks:
           LABEL_FILTER: suite-python-go && rest && python-python
           REPORT_NAME: report-agntcy-a2a-python-go-rest-python-python
 
+  test:rust-python:jsonrpc:
+    desc: Rust and Python JSON-RPC interoperability matrix
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && jsonrpc
+          REPORT_NAME: report-agntcy-a2a-rust-python-jsonrpc
+
+  test:rust-python:jsonrpc:rust-rust:
+    desc: Rust client to Rust server JSON-RPC interoperability test for the Rust/Python slice
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && jsonrpc && rust-rust
+          REPORT_NAME: report-agntcy-a2a-rust-python-jsonrpc-rust-rust
+
+  test:rust-python:jsonrpc:rust-python:
+    desc: Rust client to Python server JSON-RPC interoperability test
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && jsonrpc && rust-python
+          REPORT_NAME: report-agntcy-a2a-rust-python-jsonrpc-rust-python
+
+  test:rust-python:jsonrpc:python-rust:
+    desc: Python client to Rust server JSON-RPC interoperability test
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && jsonrpc && python-rust
+          REPORT_NAME: report-agntcy-a2a-rust-python-jsonrpc-python-rust
+
+  test:rust-python:jsonrpc:python-python:
+    desc: Python client to Python server JSON-RPC interoperability test for the Rust/Python slice
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && jsonrpc && python-python
+          REPORT_NAME: report-agntcy-a2a-rust-python-jsonrpc-python-python
+
+  test:rust-python:rest:
+    desc: Rust and Python HTTP+JSON interoperability matrix
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && rest
+          REPORT_NAME: report-agntcy-a2a-rust-python-rest
+
+  test:rust-python:rest:rust-rust:
+    desc: Rust client to Rust server HTTP+JSON interoperability test for the Rust/Python slice
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && rest && rust-rust
+          REPORT_NAME: report-agntcy-a2a-rust-python-rest-rust-rust
+
+  test:rust-python:rest:rust-python:
+    desc: Rust client to Python server HTTP+JSON interoperability test
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && rest && rust-python
+          REPORT_NAME: report-agntcy-a2a-rust-python-rest-rust-python
+
+  test:rust-python:rest:python-rust:
+    desc: Python client to Rust server HTTP+JSON interoperability test
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && rest && python-rust
+          REPORT_NAME: report-agntcy-a2a-rust-python-rest-python-rust
+
+  test:rust-python:rest:python-python:
+    desc: Python client to Python server HTTP+JSON interoperability test for the Rust/Python slice
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && rest && python-python
+          REPORT_NAME: report-agntcy-a2a-rust-python-rest-python-python
+
   test:rust-go:jsonrpc:
     desc: Rust and Go JSON-RPC interoperability matrix
     cmds:
@@ -517,6 +646,14 @@ tasks:
           REPORT_NAME: '{{.REPORT_NAME}}'
 
   test:python-go:run:
+    internal: true
+    cmds:
+      - task: test:interop:run
+        vars:
+          LABEL_FILTER: '{{.LABEL_FILTER}}'
+          REPORT_NAME: '{{.REPORT_NAME}}'
+
+  test:rust-python:run:
     internal: true
     cmds:
       - task: test:interop:run

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
@@ -1,0 +1,868 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2A Python v1.0 interoperability probe.
+
+This probe is the Python-client analogue of the existing Rust and .NET probes.
+It exercises one shared behavior slice at a time so the Go Ginkgo layer can
+reuse the same behavior matrix across SDKs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from uuid import uuid4
+
+import httpx
+
+from google.protobuf.json_format import MessageToDict, ParseDict
+
+from a2a.client import Client, ClientConfig, create_client
+from a2a.types import a2a_pb2
+from a2a.utils.constants import (
+    PROTOCOL_VERSION_1_0,
+    TransportProtocol,
+    VERSION_HEADER,
+)
+
+
+REQUEST_TEXT = 'ping'
+PENDING_REQUEST_TEXT = 'pending'
+MESSAGE_ONLY_REQUEST_TEXT = 'message-only'
+TASK_FAILURE_REQUEST_TEXT = 'task-failure'
+MULTI_TURN_START_REQUEST_TEXT = 'multi-turn start'
+MULTI_TURN_CONTINUE_REQUEST_TEXT = 'multi-turn continue'
+STREAMING_REQUEST_TEXT = 'streaming'
+LONG_RUNNING_REQUEST_TEXT = 'long-running'
+DATA_TYPES_REQUEST_TEXT = 'data-types'
+REQUEST_DATA_KIND = 'structured'
+REQUEST_DATA_SCOPE = 'interop'
+REQUEST_METADATA_KEY = 'csit'
+REQUEST_METADATA_VALUE = 'multipart'
+EXTENDED_CARD_SCHEME_ID = 'bearer_token'
+
+
+def build_text_part(text: str) -> a2a_pb2.Part:
+    return a2a_pb2.Part(text=text)
+
+
+def build_data_part(data: dict[str, object]) -> a2a_pb2.Part:
+    part = a2a_pb2.Part()
+    ParseDict({'data': data}, part)
+    return part
+
+
+def new_request(
+    text: str,
+    return_immediately: bool,
+    task_id: str = '',
+    context_id: str = '',
+) -> a2a_pb2.SendMessageRequest:
+    message = a2a_pb2.Message(
+        role=a2a_pb2.Role.ROLE_USER,
+        message_id=str(uuid4()),
+    )
+    if task_id:
+        message.task_id = task_id
+    if context_id:
+        message.context_id = context_id
+    message.parts.append(build_text_part(text))
+    message.parts.append(build_data_part({'kind': REQUEST_DATA_KIND, 'scope': REQUEST_DATA_SCOPE}))
+    message.metadata.update({REQUEST_METADATA_KEY: REQUEST_METADATA_VALUE})
+
+    return a2a_pb2.SendMessageRequest(
+        message=message,
+        configuration=a2a_pb2.SendMessageConfiguration(
+            return_immediately=return_immediately,
+        ),
+    )
+
+
+def first_message_text(message: a2a_pb2.Message) -> str:
+    for part in message.parts:
+        if part.text:
+            return part.text
+    raise AssertionError('message did not include a text part')
+
+
+def task_status_text(task: a2a_pb2.Task) -> str:
+    if not task.HasField('status') or not task.status.HasField('message'):
+        raise AssertionError('task status did not include a message')
+    return first_message_text(task.status.message)
+
+
+def value_to_dict(part: a2a_pb2.Part) -> dict[str, object]:
+    return MessageToDict(part.data)
+
+
+def metadata_to_dict(message: a2a_pb2.Message) -> dict[str, object]:
+    return MessageToDict(message.metadata)
+
+
+def assert_message_payload(message: a2a_pb2.Message, expected_text: str, kind: str) -> None:
+    if first_message_text(message) != expected_text:
+        raise AssertionError(f'{kind}: unexpected text payload')
+    if len(message.parts) != 2:
+        raise AssertionError(f'{kind}: expected 2 message parts, got {len(message.parts)}')
+    data_part = value_to_dict(message.parts[1])
+    if data_part.get('kind') != REQUEST_DATA_KIND or data_part.get('scope') != REQUEST_DATA_SCOPE:
+        raise AssertionError(f'{kind}: unexpected structured data payload {data_part!r}')
+    metadata = metadata_to_dict(message)
+    if metadata.get(REQUEST_METADATA_KEY) != REQUEST_METADATA_VALUE:
+        raise AssertionError(f'{kind}: unexpected metadata payload {metadata!r}')
+
+
+def assert_task_history_payloads(task: a2a_pb2.Task, expected_texts: list[str], kind: str) -> None:
+    if len(task.history) != len(expected_texts):
+        raise AssertionError(f'{kind}: expected {len(expected_texts)} history entries, got {len(task.history)}')
+    for index, expected_text in enumerate(expected_texts):
+        assert_message_payload(task.history[index], expected_text, kind)
+
+
+def assert_task_push_config(
+    config: a2a_pb2.TaskPushNotificationConfig,
+    task_id: str,
+    expected: a2a_pb2.TaskPushNotificationConfig,
+    kind: str,
+) -> None:
+    if config.task_id != task_id:
+        raise AssertionError(f'{kind}: unexpected task_id {config.task_id!r}')
+    if config.id != expected.id or config.url != expected.url or config.token != expected.token:
+        raise AssertionError(f'{kind}: unexpected push config payload')
+    if config.authentication.scheme != expected.authentication.scheme:
+        raise AssertionError(f'{kind}: unexpected auth scheme {config.authentication.scheme!r}')
+    if config.authentication.credentials != expected.authentication.credentials:
+        raise AssertionError(f'{kind}: unexpected auth credentials')
+
+
+def assert_data_types_task(task: a2a_pb2.Task) -> None:
+    if len(task.artifacts) != 1:
+        raise AssertionError(f'data-types: expected 1 artifact, got {len(task.artifacts)}')
+    artifact = task.artifacts[0]
+    if len(artifact.parts) != 3:
+        raise AssertionError(f'data-types: expected 3 artifact parts, got {len(artifact.parts)}')
+    if artifact.parts[0].text != 'structured summary':
+        raise AssertionError('data-types: unexpected artifact summary text')
+    data_part = value_to_dict(artifact.parts[1])
+    if data_part != {'kind': 'report', 'items': 2.0}:
+        raise AssertionError(f'data-types: unexpected structured artifact payload {data_part!r}')
+    if artifact.parts[2].url != 'https://example.invalid/diagram.svg':
+        raise AssertionError('data-types: unexpected artifact URL')
+    if artifact.parts[2].media_type != 'image/svg+xml':
+        raise AssertionError('data-types: unexpected artifact media type')
+
+
+def assert_extended_card_metadata(card: a2a_pb2.AgentCard) -> None:
+    if not card.capabilities.extended_agent_card:
+        raise AssertionError('extended-card: capability flag was not set')
+    if '(extended)' not in card.description:
+        raise AssertionError('extended-card: description did not include extended marker')
+    if EXTENDED_CARD_SCHEME_ID not in card.security_schemes:
+        raise AssertionError('extended-card: bearer_token security scheme missing')
+    scheme = card.security_schemes[EXTENDED_CARD_SCHEME_ID]
+    if scheme.http_auth_security_scheme.scheme != 'Bearer':
+        raise AssertionError('extended-card: unexpected HTTP auth scheme')
+    skill_ids = {skill.id for skill in card.skills}
+    expected_skills = {
+        'message-only',
+        'task-lifecycle',
+        'task-failure',
+        'task-cancel',
+        'multi-turn',
+        'streaming',
+        'long-running',
+        'data-types',
+    }
+    if skill_ids != expected_skills:
+        raise AssertionError(f'extended-card: unexpected skills {sorted(skill_ids)!r}')
+
+
+class JsonRpcCompatError(RuntimeError):
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+
+class RestCompatError(RuntimeError):
+    def __init__(self, status_code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.data = data
+
+
+async def load_agent_card(card_url: str) -> a2a_pb2.AgentCard:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await client.get(card_url)
+        response.raise_for_status()
+        payload = response.json()
+    return ParseDict(payload, a2a_pb2.AgentCard())
+
+
+def primary_interface(card: a2a_pb2.AgentCard) -> a2a_pb2.AgentInterface:
+    if not card.supported_interfaces:
+        raise AssertionError('agent card did not expose any supported interfaces')
+
+    for protocol_binding in (TransportProtocol.JSONRPC.value, TransportProtocol.HTTP_JSON.value):
+        for interface in card.supported_interfaces:
+            if interface.protocol_binding == protocol_binding:
+                return interface
+
+    return card.supported_interfaces[0]
+
+
+def normalize_push_config_json(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+
+    if 'config' in normalized and isinstance(normalized['config'], dict):
+        config = dict(normalized.pop('config'))
+        if 'auth' in config and 'authentication' not in config:
+            config['authentication'] = config.pop('auth')
+        if 'id' not in normalized and 'id' in config:
+            normalized['id'] = config['id']
+        for key in ('url', 'token', 'authentication'):
+            if key not in normalized and key in config:
+                normalized[key] = config[key]
+
+    if 'auth' in normalized and 'authentication' not in normalized:
+        normalized['authentication'] = normalized.pop('auth')
+
+    return normalized
+
+
+def build_create_push_config_params(
+    config: a2a_pb2.TaskPushNotificationConfig,
+) -> dict[str, Any]:
+    config_payload = MessageToDict(config, preserving_proto_field_name=False)
+    config_payload.pop('tenant', None)
+    config_payload.pop('taskId', None)
+    return {
+        'taskId': config.task_id,
+        'config': config_payload,
+    }
+
+
+def build_rest_create_push_config_payload(
+    config: a2a_pb2.TaskPushNotificationConfig,
+) -> dict[str, Any]:
+    return {'config': build_create_push_config_params(config)['config']}
+
+
+def parse_push_config_entry(payload: dict[str, Any]) -> a2a_pb2.TaskPushNotificationConfig:
+    return ParseDict(
+        normalize_push_config_json(payload),
+        a2a_pb2.TaskPushNotificationConfig(),
+    )
+
+
+def parse_push_config_list_result(result: Any) -> list[a2a_pb2.TaskPushNotificationConfig]:
+    if isinstance(result, list):
+        entries = result
+    elif isinstance(result, dict):
+        entries = result.get('configs')
+        if not isinstance(entries, list):
+            raise AssertionError(f'list push configs: unexpected JSON-RPC result {result!r}')
+    else:
+        raise AssertionError(f'list push configs: unexpected JSON-RPC result {result!r}')
+
+    configs: list[a2a_pb2.TaskPushNotificationConfig] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise AssertionError(f'list push configs: unexpected JSON-RPC entry {entry!r}')
+        configs.append(parse_push_config_entry(entry))
+    return configs
+
+
+async def send_jsonrpc_request(
+    rpc_url: str,
+    method: str,
+    params: dict[str, Any],
+    *,
+    allow_missing_result: bool = False,
+) -> Any:
+    payload = {
+        'jsonrpc': '2.0',
+        'id': str(uuid4()),
+        'method': method,
+        'params': params,
+    }
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await client.post(
+            rpc_url,
+            json=payload,
+            headers={VERSION_HEADER: PROTOCOL_VERSION_1_0},
+        )
+        response.raise_for_status()
+        response_payload = response.json()
+
+    error = response_payload.get('error')
+    if isinstance(error, dict):
+        code = error.get('code')
+        if not isinstance(code, int):
+            code = 0
+        raise JsonRpcCompatError(
+            code,
+            str(error.get('message', 'JSON-RPC request failed')),
+            error.get('data'),
+        )
+
+    if 'result' not in response_payload:
+        if allow_missing_result:
+            return None
+        raise AssertionError(f'JSON-RPC response for {method} did not include a result')
+
+    return response_payload['result']
+
+
+async def send_rest_request(
+    method: str,
+    url: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+) -> Any:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await client.request(
+            method,
+            url,
+            json=json_body,
+            headers={VERSION_HEADER: PROTOCOL_VERSION_1_0},
+        )
+
+    if response.status_code >= 400:
+        try:
+            payload = response.json()
+        except json.JSONDecodeError:
+            payload = None
+        raise RestCompatError(response.status_code, response.text, payload)
+
+    if response.status_code == 204 or not response.content:
+        return None
+    return response.json()
+
+
+async def create_task_push_config_jsonrpc(
+    rpc_url: str,
+    config: a2a_pb2.TaskPushNotificationConfig,
+) -> a2a_pb2.TaskPushNotificationConfig:
+    result = await send_jsonrpc_request(
+        rpc_url,
+        'CreateTaskPushNotificationConfig',
+        build_create_push_config_params(config),
+    )
+    if not isinstance(result, dict):
+        raise AssertionError(f'create push config: unexpected JSON-RPC result {result!r}')
+    return parse_push_config_entry(result)
+
+
+async def get_task_push_config_jsonrpc(
+    rpc_url: str,
+    request: a2a_pb2.GetTaskPushNotificationConfigRequest,
+) -> a2a_pb2.TaskPushNotificationConfig:
+    result = await send_jsonrpc_request(
+        rpc_url,
+        'GetTaskPushNotificationConfig',
+        MessageToDict(request, preserving_proto_field_name=False),
+    )
+    if not isinstance(result, dict):
+        raise AssertionError(f'get push config: unexpected JSON-RPC result {result!r}')
+    return parse_push_config_entry(result)
+
+
+async def list_task_push_configs_jsonrpc(
+    rpc_url: str,
+    request: a2a_pb2.ListTaskPushNotificationConfigsRequest,
+) -> list[a2a_pb2.TaskPushNotificationConfig]:
+    result = await send_jsonrpc_request(
+        rpc_url,
+        'ListTaskPushNotificationConfigs',
+        MessageToDict(request, preserving_proto_field_name=False),
+    )
+    return parse_push_config_list_result(result)
+
+
+async def delete_task_push_config_jsonrpc(
+    rpc_url: str,
+    request: a2a_pb2.DeleteTaskPushNotificationConfigRequest,
+) -> None:
+    await send_jsonrpc_request(
+        rpc_url,
+        'DeleteTaskPushNotificationConfig',
+        MessageToDict(request, preserving_proto_field_name=False),
+        allow_missing_result=True,
+    )
+
+
+async def create_task_push_config_rest(
+    base_url: str,
+    config: a2a_pb2.TaskPushNotificationConfig,
+) -> a2a_pb2.TaskPushNotificationConfig:
+    result = await send_rest_request(
+        'POST',
+        f"{base_url.rstrip('/')}/tasks/{config.task_id}/pushNotificationConfigs",
+        json_body=build_rest_create_push_config_payload(config),
+    )
+    if not isinstance(result, dict):
+        raise AssertionError(f'create push config: unexpected REST result {result!r}')
+    return parse_push_config_entry(result)
+
+
+async def get_task_push_config_rest(
+    base_url: str,
+    request: a2a_pb2.GetTaskPushNotificationConfigRequest,
+) -> a2a_pb2.TaskPushNotificationConfig:
+    result = await send_rest_request(
+        'GET',
+        f"{base_url.rstrip('/')}/tasks/{request.task_id}/pushNotificationConfigs/{request.id}",
+    )
+    if not isinstance(result, dict):
+        raise AssertionError(f'get push config: unexpected REST result {result!r}')
+    return parse_push_config_entry(result)
+
+
+async def list_task_push_configs_rest(
+    base_url: str,
+    request: a2a_pb2.ListTaskPushNotificationConfigsRequest,
+) -> list[a2a_pb2.TaskPushNotificationConfig]:
+    result = await send_rest_request(
+        'GET',
+        f"{base_url.rstrip('/')}/tasks/{request.task_id}/pushNotificationConfigs",
+    )
+    return parse_push_config_list_result(result)
+
+
+async def delete_task_push_config_rest(
+    base_url: str,
+    request: a2a_pb2.DeleteTaskPushNotificationConfigRequest,
+) -> None:
+    await send_rest_request(
+        'DELETE',
+        f"{base_url.rstrip('/')}/tasks/{request.task_id}/pushNotificationConfigs/{request.id}",
+    )
+
+
+async def create_probe_client(card_url: str, streaming: bool) -> Client:
+    config = ClientConfig(
+        streaming=streaming,
+        supported_protocol_bindings=[
+            TransportProtocol.JSONRPC,
+            TransportProtocol.HTTP_JSON,
+        ],
+        httpx_client=httpx.AsyncClient(timeout=5.0),
+    )
+    return await create_client(card_url, client_config=config)
+
+
+async def collect_responses(
+    client: Client,
+    request: a2a_pb2.SendMessageRequest,
+) -> list[a2a_pb2.StreamResponse]:
+    responses: list[a2a_pb2.StreamResponse] = []
+    async for response in client.send_message(request):
+        responses.append(response)
+    return responses
+
+
+def expect_task_response(response: a2a_pb2.StreamResponse, kind: str) -> a2a_pb2.Task:
+    if not response.HasField('task'):
+        raise AssertionError(f'{kind}: expected task response')
+    return response.task
+
+
+def expect_message_response(response: a2a_pb2.StreamResponse, kind: str) -> a2a_pb2.Message:
+    if not response.HasField('message'):
+        raise AssertionError(f'{kind}: expected message response')
+    return response.message
+
+
+async def expect_error(awaitable: asyncio.Future | asyncio.Task | object, expected_substring: str) -> None:
+    try:
+        await awaitable  # type: ignore[arg-type]
+    except Exception as exc:  # noqa: BLE001
+        if expected_substring.lower() not in str(exc).lower():
+            raise AssertionError(f'expected error containing {expected_substring!r}, got {exc!r}') from exc
+        return
+    raise AssertionError(f'expected error containing {expected_substring!r}')
+
+
+async def wait_for_task_state(client: Client, task_id: str, expected_state: int) -> a2a_pb2.Task:
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while asyncio.get_running_loop().time() < deadline:
+        task = await client.get_task(a2a_pb2.GetTaskRequest(id=task_id))
+        if task.status.state == expected_state:
+            return task
+        await asyncio.sleep(0.05)
+    raise AssertionError(f'timed out waiting for task {task_id} to reach state {expected_state}')
+
+
+async def assert_unary_streaming(card_url: str, server_prefix: str) -> None:
+    unary_client = await create_probe_client(card_url, streaming=False)
+    try:
+        unary_responses = await collect_responses(unary_client, new_request(REQUEST_TEXT, False))
+        if len(unary_responses) != 1:
+            raise AssertionError(f'unary: expected exactly one response, got {len(unary_responses)}')
+        unary_task = expect_task_response(unary_responses[0], 'unary')
+        if task_status_text(unary_task) != f'{server_prefix} server received: {REQUEST_TEXT}':
+            raise AssertionError('unary: unexpected response text')
+    finally:
+        await unary_client.close()
+
+    streaming_client = await create_probe_client(card_url, streaming=True)
+    try:
+        streaming_responses = await collect_responses(streaming_client, new_request(REQUEST_TEXT, False))
+        texts: list[str] = []
+        for response in streaming_responses:
+            if response.HasField('task'):
+                texts.append(task_status_text(response.task))
+            elif response.HasField('message'):
+                texts.append(first_message_text(response.message))
+            elif response.HasField('status_update') and response.status_update.status.HasField('message'):
+                texts.append(first_message_text(response.status_update.status.message))
+        if f'{server_prefix} server received: {REQUEST_TEXT}' not in texts:
+            raise AssertionError(f'streaming: expected response text in {texts!r}')
+    finally:
+        await streaming_client.close()
+
+
+async def assert_task_lifecycle(card_url: str, server_prefix: str) -> None:
+    client = await create_probe_client(card_url, streaming=False)
+    try:
+        completed_task = expect_task_response(
+            (await collect_responses(client, new_request(REQUEST_TEXT, False)))[0],
+            'completed task',
+        )
+        if completed_task.status.state != a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+            raise AssertionError('completed task: expected completed state')
+        if task_status_text(completed_task) != f'{server_prefix} server received: {REQUEST_TEXT}':
+            raise AssertionError('completed task: unexpected status text')
+        assert_task_history_payloads(completed_task, [REQUEST_TEXT], 'completed task history')
+
+        fetched_task = await client.get_task(a2a_pb2.GetTaskRequest(id=completed_task.id))
+        if fetched_task.status.state != a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+            raise AssertionError('fetched task: expected completed state')
+        if task_status_text(fetched_task) != f'{server_prefix} server received: {REQUEST_TEXT}':
+            raise AssertionError('fetched task: unexpected status text')
+        assert_task_history_payloads(fetched_task, [REQUEST_TEXT], 'fetched task history')
+
+        listed_tasks = await client.list_tasks(
+            a2a_pb2.ListTasksRequest(context_id=completed_task.context_id)
+        )
+        if not any(task.id == completed_task.id for task in listed_tasks.tasks):
+            raise AssertionError('list tasks: completed task id was not returned')
+
+        pending_task = expect_task_response(
+            (await collect_responses(client, new_request(PENDING_REQUEST_TEXT, True)))[0],
+            'pending task',
+        )
+        if pending_task.status.state != a2a_pb2.TaskState.TASK_STATE_WORKING:
+            raise AssertionError('pending task: expected working state')
+        if task_status_text(pending_task) != f'{server_prefix} server received: {PENDING_REQUEST_TEXT}':
+            raise AssertionError('pending task: unexpected status text')
+
+        canceled_task = await client.cancel_task(a2a_pb2.CancelTaskRequest(id=pending_task.id))
+        if canceled_task.status.state != a2a_pb2.TaskState.TASK_STATE_CANCELED:
+            raise AssertionError('canceled task: expected canceled state')
+        if task_status_text(canceled_task) != f'{server_prefix} server canceled task':
+            raise AssertionError('canceled task: unexpected status text')
+
+        fetched_canceled_task = await client.get_task(a2a_pb2.GetTaskRequest(id=pending_task.id))
+        if fetched_canceled_task.status.state != a2a_pb2.TaskState.TASK_STATE_CANCELED:
+            raise AssertionError('fetched canceled task: expected canceled state')
+        if task_status_text(fetched_canceled_task) != f'{server_prefix} server canceled task':
+            raise AssertionError('fetched canceled task: unexpected status text')
+
+        await expect_error(
+            client.get_task(a2a_pb2.GetTaskRequest(id=str(uuid4()))),
+            'task',
+        )
+        await expect_error(
+            client.cancel_task(a2a_pb2.CancelTaskRequest(id=completed_task.id)),
+            'cancel',
+        )
+    finally:
+        await client.close()
+
+
+async def assert_push_config(
+    card_url: str,
+    server_prefix: str,
+    expect_push_supported: bool,
+    expected_push_error_code: int,
+    relaxed_error_checks: bool,
+) -> None:
+    client = await create_probe_client(card_url, streaming=False)
+    try:
+        card = getattr(client, '_card', None)
+        if not isinstance(card, a2a_pb2.AgentCard):
+            card = await load_agent_card(card_url)
+        agent_interface = primary_interface(card)
+        uses_jsonrpc = agent_interface.protocol_binding == TransportProtocol.JSONRPC.value
+
+        completed_task = expect_task_response(
+            (await collect_responses(client, new_request(REQUEST_TEXT, False)))[0],
+            'push-config task',
+        )
+        if completed_task.status.state != a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+            raise AssertionError('push-config task: expected completed state')
+        if task_status_text(completed_task) != f'{server_prefix} server received: {REQUEST_TEXT}':
+            raise AssertionError('push-config task: unexpected status text')
+        assert_task_history_payloads(completed_task, [REQUEST_TEXT], 'push-config task history')
+
+        push_config = a2a_pb2.TaskPushNotificationConfig(
+            task_id=completed_task.id,
+            id='interop-config',
+            url='https://example.invalid/webhook',
+            token='interop-token',
+            authentication=a2a_pb2.AuthenticationInfo(
+                scheme='Bearer',
+                credentials='interop-credential',
+            ),
+        )
+
+        if not expect_push_supported:
+            try:
+                if uses_jsonrpc:
+                    await create_task_push_config_jsonrpc(agent_interface.url, push_config)
+                else:
+                    await create_task_push_config_rest(agent_interface.url, push_config)
+            except Exception as exc:  # noqa: BLE001
+                if not relaxed_error_checks and expected_push_error_code != 0:
+                    if isinstance(exc, JsonRpcCompatError):
+                        error_text = f'{exc.code} {exc}'
+                    elif isinstance(exc, RestCompatError):
+                        error_text = f'{exc.status_code} {exc}'
+                    else:
+                        error_text = str(exc)
+                    if str(expected_push_error_code) not in error_text:
+                        raise AssertionError(
+                            f'expected push error code {expected_push_error_code}, got {error_text!r}'
+                        ) from exc
+                return
+            raise AssertionError('expected push configuration to be unsupported')
+
+        if uses_jsonrpc:
+            created_config = await create_task_push_config_jsonrpc(agent_interface.url, push_config)
+        else:
+            created_config = await create_task_push_config_rest(agent_interface.url, push_config)
+        assert_task_push_config(created_config, completed_task.id, push_config, 'created push config')
+
+        get_request = a2a_pb2.GetTaskPushNotificationConfigRequest(
+            task_id=completed_task.id,
+            id=push_config.id,
+        )
+        if uses_jsonrpc:
+            fetched_config = await get_task_push_config_jsonrpc(agent_interface.url, get_request)
+        else:
+            fetched_config = await get_task_push_config_rest(agent_interface.url, get_request)
+        assert_task_push_config(fetched_config, completed_task.id, push_config, 'fetched push config')
+
+        list_request = a2a_pb2.ListTaskPushNotificationConfigsRequest(task_id=completed_task.id)
+        if uses_jsonrpc:
+            listed_configs = await list_task_push_configs_jsonrpc(agent_interface.url, list_request)
+        else:
+            listed_configs = await list_task_push_configs_rest(agent_interface.url, list_request)
+
+        if len(listed_configs) != 1:
+            raise AssertionError('list push configs: expected one config')
+        assert_task_push_config(listed_configs[0], completed_task.id, push_config, 'listed push config')
+
+        delete_request = a2a_pb2.DeleteTaskPushNotificationConfigRequest(
+            task_id=completed_task.id,
+            id=push_config.id,
+        )
+        if uses_jsonrpc:
+            await delete_task_push_config_jsonrpc(agent_interface.url, delete_request)
+            listed_configs = await list_task_push_configs_jsonrpc(agent_interface.url, list_request)
+        else:
+            await delete_task_push_config_rest(agent_interface.url, delete_request)
+            listed_configs = await list_task_push_configs_rest(agent_interface.url, list_request)
+
+        if listed_configs:
+            raise AssertionError('list push configs after delete: expected no configs')
+    finally:
+        await client.close()
+
+
+async def assert_scenario_parity(card_url: str, server_prefix: str) -> None:
+    unary_client = await create_probe_client(card_url, streaming=False)
+    streaming_client = await create_probe_client(card_url, streaming=True)
+    try:
+        message_only = expect_message_response(
+            (await collect_responses(unary_client, new_request(MESSAGE_ONLY_REQUEST_TEXT, False)))[0],
+            'message-only',
+        )
+        if first_message_text(message_only) != f'{server_prefix} server message-only response':
+            raise AssertionError('message-only: unexpected response text')
+
+        failed_task = expect_task_response(
+            (await collect_responses(unary_client, new_request(TASK_FAILURE_REQUEST_TEXT, False)))[0],
+            'task-failure',
+        )
+        if failed_task.status.state != a2a_pb2.TaskState.TASK_STATE_FAILED:
+            raise AssertionError('task-failure: expected failed state')
+        if task_status_text(failed_task) != f'{server_prefix} server failed task':
+            raise AssertionError('task-failure: unexpected status text')
+
+        input_required_task = expect_task_response(
+            (await collect_responses(unary_client, new_request(MULTI_TURN_START_REQUEST_TEXT, False)))[0],
+            'multi-turn start',
+        )
+        if input_required_task.status.state != a2a_pb2.TaskState.TASK_STATE_INPUT_REQUIRED:
+            raise AssertionError('multi-turn start: expected input-required state')
+        if task_status_text(input_required_task) != f'{server_prefix} server needs more input':
+            raise AssertionError('multi-turn start: unexpected status text')
+        assert_task_history_payloads(input_required_task, [MULTI_TURN_START_REQUEST_TEXT], 'multi-turn start')
+
+        continued_task = expect_task_response(
+            (
+                await collect_responses(
+                    unary_client,
+                    new_request(
+                        MULTI_TURN_CONTINUE_REQUEST_TEXT,
+                        False,
+                        task_id=input_required_task.id,
+                        context_id=input_required_task.context_id,
+                    ),
+                )
+            )[0],
+            'multi-turn continue',
+        )
+        if continued_task.status.state != a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+            raise AssertionError('multi-turn continue: expected completed state')
+        if task_status_text(continued_task) != f'{server_prefix} server multi-turn completed':
+            raise AssertionError('multi-turn continue: unexpected status text')
+        assert_task_history_payloads(
+            continued_task,
+            [MULTI_TURN_START_REQUEST_TEXT, MULTI_TURN_CONTINUE_REQUEST_TEXT],
+            'multi-turn continue',
+        )
+
+        streaming_responses = await collect_responses(
+            streaming_client,
+            new_request(STREAMING_REQUEST_TEXT, False),
+        )
+        saw_streaming_start = False
+        saw_streaming_complete = False
+        saw_append = False
+        streaming_chunks: list[str] = []
+        for response in streaming_responses:
+            if response.HasField('task'):
+                saw_streaming_start = True
+                if response.task.status.state != a2a_pb2.TaskState.TASK_STATE_WORKING:
+                    raise AssertionError('streaming: expected initial working task')
+                if task_status_text(response.task) != f'{server_prefix} server streaming started':
+                    raise AssertionError('streaming: unexpected start text')
+            elif response.HasField('artifact_update'):
+                artifact = response.artifact_update.artifact
+                if not artifact.parts or not artifact.parts[0].text:
+                    raise AssertionError('streaming: artifact update missing text part')
+                streaming_chunks.append(artifact.parts[0].text)
+                if response.artifact_update.append:
+                    saw_append = True
+            elif response.HasField('status_update'):
+                saw_streaming_complete = True
+                if response.status_update.status.state != a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+                    raise AssertionError('streaming: expected completed status update')
+                if first_message_text(response.status_update.status.message) != f'{server_prefix} server streaming complete':
+                    raise AssertionError('streaming: unexpected completion text')
+            else:
+                raise AssertionError('streaming: unexpected response variant')
+        if not saw_streaming_start or not saw_streaming_complete or not saw_append:
+            raise AssertionError('streaming: missing expected task/artifact/status events')
+        if streaming_chunks != ['streaming chunk 1', 'streaming chunk 2']:
+            raise AssertionError(f'streaming: unexpected chunks {streaming_chunks!r}')
+
+        long_running_task = expect_task_response(
+            (await collect_responses(unary_client, new_request(LONG_RUNNING_REQUEST_TEXT, True)))[0],
+            'long-running',
+        )
+        if long_running_task.status.state != a2a_pb2.TaskState.TASK_STATE_WORKING:
+            raise AssertionError('long-running: expected working state')
+        if task_status_text(long_running_task) != f'{server_prefix} server long-running started':
+            raise AssertionError('long-running: unexpected start text')
+        long_running_completed = await wait_for_task_state(
+            unary_client,
+            long_running_task.id,
+            a2a_pb2.TaskState.TASK_STATE_COMPLETED,
+        )
+        if task_status_text(long_running_completed) != f'{server_prefix} server long-running complete':
+            raise AssertionError('long-running: unexpected completion text')
+
+        data_types_task = expect_task_response(
+            (await collect_responses(unary_client, new_request(DATA_TYPES_REQUEST_TEXT, False)))[0],
+            'data-types',
+        )
+        if data_types_task.status.state != a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+            raise AssertionError('data-types: expected completed state')
+        if task_status_text(data_types_task) != f'{server_prefix} server data-types ready':
+            raise AssertionError('data-types: unexpected status text')
+        assert_data_types_task(data_types_task)
+
+        extended_card = await unary_client.get_extended_agent_card(
+            a2a_pb2.GetExtendedAgentCardRequest()
+        )
+        assert_extended_card_metadata(extended_card)
+    finally:
+        await unary_client.close()
+        await streaming_client.close()
+
+
+async def run_scenario(args: argparse.Namespace) -> None:
+    if args.scenario == 'core':
+        await assert_unary_streaming(args.card_url, args.server_prefix)
+        await assert_task_lifecycle(args.card_url, args.server_prefix)
+        await assert_push_config(
+            args.card_url,
+            args.server_prefix,
+            not args.expect_push_unsupported,
+            args.expected_push_error_code,
+            args.relaxed_error_checks,
+        )
+        return
+    if args.scenario == 'unary-streaming':
+        await assert_unary_streaming(args.card_url, args.server_prefix)
+        return
+    if args.scenario == 'task-lifecycle':
+        await assert_task_lifecycle(args.card_url, args.server_prefix)
+        return
+    if args.scenario == 'push-config':
+        await assert_push_config(
+            args.card_url,
+            args.server_prefix,
+            not args.expect_push_unsupported,
+            args.expected_push_error_code,
+            args.relaxed_error_checks,
+        )
+        return
+    if args.scenario == 'parity':
+        await assert_scenario_parity(args.card_url, args.server_prefix)
+        return
+    raise AssertionError(f'unsupported scenario {args.scenario!r}')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Run the Python A2A interop probe.')
+    parser.add_argument('--card-url', required=True)
+    parser.add_argument('--server-prefix', required=True)
+    parser.add_argument(
+        '--scenario',
+        default='core',
+        choices=('core', 'unary-streaming', 'task-lifecycle', 'push-config', 'parity'),
+    )
+    parser.add_argument('--expect-push-supported', action='store_true')
+    parser.add_argument('--expect-push-unsupported', action='store_true')
+    parser.add_argument('--expected-push-error-code', type=int, default=0)
+    parser.add_argument('--relaxed-error-checks', action='store_true')
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(run_scenario(args))
+
+
+if __name__ == '__main__':
+    main()

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
@@ -248,8 +248,16 @@ def build_create_push_config_params(
 
 def build_rest_create_push_config_payload(
     config: a2a_pb2.TaskPushNotificationConfig,
+    *,
+    nested_config: bool,
 ) -> dict[str, Any]:
-    return {'config': build_create_push_config_params(config)['config']}
+    config_payload = build_create_push_config_params(config)['config']
+    if nested_config:
+        return {'config': config_payload}
+
+    flat_payload = dict(config_payload)
+    flat_payload['taskId'] = config.task_id
+    return flat_payload
 
 
 def parse_push_config_entry(payload: dict[str, Any]) -> a2a_pb2.TaskPushNotificationConfig:
@@ -399,11 +407,16 @@ async def delete_task_push_config_jsonrpc(
 async def create_task_push_config_rest(
     base_url: str,
     config: a2a_pb2.TaskPushNotificationConfig,
+    *,
+    nested_config: bool,
 ) -> a2a_pb2.TaskPushNotificationConfig:
     result = await send_rest_request(
         'POST',
         f"{base_url.rstrip('/')}/tasks/{config.task_id}/pushNotificationConfigs",
-        json_body=build_rest_create_push_config_payload(config),
+        json_body=build_rest_create_push_config_payload(
+            config,
+            nested_config=nested_config,
+        ),
     )
     if not isinstance(result, dict):
         raise AssertionError(f'create push config: unexpected REST result {result!r}')
@@ -600,6 +613,7 @@ async def assert_push_config(
             card = await load_agent_card(card_url)
         agent_interface = primary_interface(card)
         uses_jsonrpc = agent_interface.protocol_binding == TransportProtocol.JSONRPC.value
+        uses_nested_rest_push_config = server_prefix != 'rust'
 
         completed_task = expect_task_response(
             (await collect_responses(client, new_request(REQUEST_TEXT, False)))[0],
@@ -627,7 +641,11 @@ async def assert_push_config(
                 if uses_jsonrpc:
                     await create_task_push_config_jsonrpc(agent_interface.url, push_config)
                 else:
-                    await create_task_push_config_rest(agent_interface.url, push_config)
+                    await create_task_push_config_rest(
+                        agent_interface.url,
+                        push_config,
+                        nested_config=uses_nested_rest_push_config,
+                    )
             except Exception as exc:  # noqa: BLE001
                 if not relaxed_error_checks and expected_push_error_code != 0:
                     if isinstance(exc, JsonRpcCompatError):
@@ -646,7 +664,11 @@ async def assert_push_config(
         if uses_jsonrpc:
             created_config = await create_task_push_config_jsonrpc(agent_interface.url, push_config)
         else:
-            created_config = await create_task_push_config_rest(agent_interface.url, push_config)
+            created_config = await create_task_push_config_rest(
+                agent_interface.url,
+                push_config,
+                nested_config=uses_nested_rest_push_config,
+            )
         assert_task_push_config(created_config, completed_task.id, push_config, 'created push config')
 
         get_request = a2a_pb2.GetTaskPushNotificationConfigRequest(

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
@@ -18,6 +18,7 @@ import argparse
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -25,8 +26,9 @@ import uvicorn
 
 from google.protobuf.json_format import MessageToDict, ParseDict
 from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
@@ -45,7 +47,10 @@ from a2a.server.tasks import (
 )
 from a2a.types import a2a_pb2
 from a2a.utils import TransportProtocol, get_message_text, new_task
-from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH, PROTOCOL_VERSION_1_0
+from a2a.utils.error_handlers import rest_error_handler
+from a2a.utils.errors import TaskNotFoundError
+from a2a.utils.helpers import validate_version
 
 
 LOGGER = logging.getLogger(__name__)
@@ -384,6 +389,49 @@ def forward_response_headers(response: Response) -> dict[str, str]:
     }
 
 
+async def normalize_sse_body(response: Response) -> AsyncIterator[bytes]:
+    pending = b''
+
+    async for chunk in response.body_iterator:
+        data = chunk if isinstance(chunk, bytes) else chunk.encode()
+        pending += data
+
+        if not pending:
+            continue
+
+        if pending.endswith(b'\r'):
+            emit = pending[:-1]
+            pending = b'\r'
+        else:
+            emit = pending
+            pending = b''
+
+        if emit:
+            yield emit.replace(b'\r\n', b'\n')
+
+    if pending:
+        yield pending.replace(b'\r\n', b'\n')
+
+
+def normalize_sse_response(response: Response) -> Response:
+    return StreamingResponse(
+        normalize_sse_body(response),
+        status_code=response.status_code,
+        headers=forward_response_headers(response),
+        media_type='text/event-stream',
+        background=response.background,
+    )
+
+
+class SSELineEndingsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        content_type = response.headers.get('content-type', '')
+        if 'text/event-stream' not in content_type.lower():
+            return response
+        return normalize_sse_response(response)
+
+
 def create_jsonrpc_routes_with_compat(request_handler: LegacyRequestHandler) -> list[Route]:
     dispatcher = JsonRpcDispatcher(request_handler=request_handler)
 
@@ -494,6 +542,30 @@ def create_rest_routes_with_compat(request_handler: LegacyRequestHandler) -> lis
             )
         )
 
+    @rest_error_handler
+    async def get_task_endpoint(request: Request) -> Response:
+        @validate_version(PROTOCOL_VERSION_1_0)
+        async def _handler(context: ServerCallContext) -> a2a_pb2.Task:
+            params = a2a_pb2.GetTaskRequest(id=request.path_params['id'])
+
+            history_length = request.query_params.get('historyLength')
+            if history_length:
+                params.history_length = int(history_length)
+
+            task = await request_handler.on_get_task(params, context)
+            if task:
+                return task
+            raise TaskNotFoundError
+
+        response = await _handler(build_context(request))
+        return JSONResponse(
+            content=MessageToDict(
+                response,
+                preserving_proto_field_name=False,
+                always_print_fields_with_no_presence=True,
+            )
+        )
+
     async def delete_push_config_endpoint(request: Request) -> Response:
         await request_handler.on_delete_task_push_notification_config(
             a2a_pb2.DeleteTaskPushNotificationConfigRequest(
@@ -545,6 +617,7 @@ def create_rest_routes_with_compat(request_handler: LegacyRequestHandler) -> lis
         Route(path='/tasks/{id}/pushNotificationConfigs', endpoint=list_push_configs_endpoint, methods=['GET']),
         Route(path='/tasks/{id}/pushNotificationConfigs/{push_id}', endpoint=get_push_config_endpoint, methods=['GET']),
         Route(path='/tasks/{id}/pushNotificationConfigs/{push_id}', endpoint=delete_push_config_endpoint, methods=['DELETE']),
+        Route(path='/tasks/{id}', endpoint=get_task_endpoint, methods=['GET']),
         Route(path='/tasks', endpoint=list_tasks_endpoint, methods=['GET']),
         *rest_routes,
     ]
@@ -728,7 +801,9 @@ def build_app(port: int, protocol: str) -> Starlette:
     else:
         routes.extend(create_jsonrpc_routes_with_compat(request_handler))
 
-    return Starlette(routes=routes)
+    app = Starlette(routes=routes)
+    app.add_middleware(SSELineEndingsMiddleware)
+    return app
 
 
 def parse_args() -> argparse.Namespace:

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
@@ -1,0 +1,757 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2A Python v1.0 interoperability fixture server.
+
+This server mirrors the behavior contract already exercised by the shared Go
+interop suite, but implements it using the Python SDK from the
+release-please--branches--1.0-dev branch.
+
+Use this file when adding or adjusting Python server-side parity behavior. Keep
+transport bootstrapping in this file and leave cross-SDK assertions in the Go
+test harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import uvicorn
+
+from google.protobuf.json_format import MessageToDict, ParseDict
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.context import ServerCallContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import LegacyRequestHandler
+from a2a.server.routes import (
+    create_agent_card_routes,
+    create_rest_routes,
+)
+from a2a.server.routes.common import DefaultServerCallContextBuilder
+from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
+from a2a.server.tasks import (
+    InMemoryPushNotificationConfigStore,
+    InMemoryTaskStore,
+)
+from a2a.types import a2a_pb2
+from a2a.utils import TransportProtocol, get_message_text, new_task
+from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+
+
+LOGGER = logging.getLogger(__name__)
+
+SERVER_PREFIX = 'python'
+PENDING_REQUEST_TEXT = 'pending'
+MESSAGE_ONLY_REQUEST_TEXT = 'message-only'
+TASK_FAILURE_REQUEST_TEXT = 'task-failure'
+MULTI_TURN_START_REQUEST_TEXT = 'multi-turn start'
+MULTI_TURN_CONTINUE_REQUEST_TEXT = 'multi-turn continue'
+STREAMING_REQUEST_TEXT = 'streaming'
+LONG_RUNNING_REQUEST_TEXT = 'long-running'
+DATA_TYPES_REQUEST_TEXT = 'data-types'
+EXTENDED_CARD_SCHEME_ID = 'bearer_token'
+JSONRPC_PUSH_COMPAT_METHODS = {
+    'CreateTaskPushNotificationConfig',
+    'GetTaskPushNotificationConfig',
+    'ListTaskPushNotificationConfigs',
+    'DeleteTaskPushNotificationConfig',
+}
+
+
+def build_text_part(text: str) -> a2a_pb2.Part:
+    return a2a_pb2.Part(text=text)
+
+
+def build_data_part(data: dict[str, object]) -> a2a_pb2.Part:
+    part = a2a_pb2.Part()
+    ParseDict({'data': data}, part)
+    return part
+
+
+def build_agent_message(task_id: str, context_id: str, text: str) -> a2a_pb2.Message:
+    return a2a_pb2.Message(
+        role=a2a_pb2.Role.ROLE_AGENT,
+        task_id=task_id,
+        context_id=context_id,
+        message_id=str(uuid4()),
+        parts=[build_text_part(text)],
+    )
+
+
+def build_task(context: RequestContext, state: int, text: str) -> a2a_pb2.Task:
+    if context.current_task is not None:
+        task = a2a_pb2.Task()
+        task.CopyFrom(context.current_task)
+        if task.history:
+            user_history = [entry for entry in task.history if entry.role == a2a_pb2.Role.ROLE_USER]
+            task.ClearField('history')
+            task.history.extend(user_history)
+        if context.message is not None:
+            if not task.history or task.history[-1].message_id != context.message.message_id:
+                task.history.append(context.message)
+    else:
+        if context.message is None:
+            raise RuntimeError('message is required to construct a task')
+        task = new_task(context.message)
+
+    task.status.CopyFrom(
+        a2a_pb2.TaskStatus(
+            state=state,
+            message=build_agent_message(task.id, task.context_id, text),
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+    return task
+
+
+def build_status_update(task_id: str, context_id: str, state: int, text: str) -> a2a_pb2.TaskStatusUpdateEvent:
+    return a2a_pb2.TaskStatusUpdateEvent(
+        task_id=task_id,
+        context_id=context_id,
+        status=a2a_pb2.TaskStatus(
+            state=state,
+            message=build_agent_message(task_id, context_id, text),
+            timestamp=datetime.now(timezone.utc),
+        ),
+    )
+
+
+def build_data_types_artifact() -> a2a_pb2.Artifact:
+    return a2a_pb2.Artifact(
+        artifact_id=str(uuid4()),
+        name='data-types-artifact',
+        description='Mixed content artifact for scenario parity',
+        parts=[
+            build_text_part('structured summary'),
+            build_data_part({'kind': 'report', 'items': 2}),
+            a2a_pb2.Part(
+                url='https://example.invalid/diagram.svg',
+                media_type='image/svg+xml',
+                filename='diagram.svg',
+            ),
+        ],
+    )
+
+
+def build_skill(skill_id: str, description: str) -> a2a_pb2.AgentSkill:
+    return a2a_pb2.AgentSkill(
+        id=skill_id,
+        name=skill_id,
+        description=description,
+        tags=['csit', 'scenario-parity'],
+    )
+
+
+def scenario_skills() -> list[a2a_pb2.AgentSkill]:
+    return [
+        build_skill('message-only', 'Returns a message response without creating a task.'),
+        build_skill('task-lifecycle', 'Creates, lists, fetches, and cancels tasks.'),
+        build_skill('task-failure', 'Returns a failed task response.'),
+        build_skill('task-cancel', 'Creates a cancelable working task.'),
+        build_skill('multi-turn', 'Requests more input before completing the task.'),
+        build_skill('streaming', 'Streams task and artifact updates.'),
+        build_skill('long-running', 'Returns early and completes asynchronously.'),
+        build_skill('data-types', 'Produces text, structured data, and URL parts.'),
+    ]
+
+
+def build_agent_card(base_url: str, protocol: str, extended: bool) -> a2a_pb2.AgentCard:
+    if protocol == 'rest':
+        name = 'CSIT Python REST Agent'
+        interface = a2a_pb2.AgentInterface(
+            protocol_binding=TransportProtocol.HTTP_JSON.value,
+            protocol_version='1.0',
+            url=base_url,
+        )
+    else:
+        name = 'CSIT Python JSON-RPC Agent'
+        interface = a2a_pb2.AgentInterface(
+            protocol_binding=TransportProtocol.JSONRPC.value,
+            protocol_version='1.0',
+            url=f'{base_url}/rpc',
+        )
+
+    card = a2a_pb2.AgentCard(
+        name=name,
+        description=(
+            'Python interoperability fixture for CSIT (extended)'
+            if extended
+            else 'Python interoperability fixture for CSIT'
+        ),
+        version='1.0.0',
+        supported_interfaces=[interface],
+        capabilities=a2a_pb2.AgentCapabilities(
+            streaming=True,
+            push_notifications=True,
+            extended_agent_card=True,
+        ),
+        default_input_modes=['text/plain'],
+        default_output_modes=['text/plain'],
+        skills=scenario_skills(),
+    )
+    card.security_schemes[EXTENDED_CARD_SCHEME_ID].CopyFrom(
+        a2a_pb2.SecurityScheme(
+            http_auth_security_scheme=a2a_pb2.HTTPAuthSecurityScheme(
+                scheme='Bearer',
+                bearer_format='JWT',
+                description='Bearer token authentication',
+            )
+        )
+    )
+    return card
+
+
+class InteropPushNotificationConfigStore(InMemoryPushNotificationConfigStore):
+    async def set_info(
+        self,
+        task_id: str,
+        notification_config: a2a_pb2.TaskPushNotificationConfig,
+        context: ServerCallContext,
+    ) -> None:
+        authentication = notification_config.authentication
+        if (
+            not notification_config.url
+            and not notification_config.token
+            and not authentication.scheme
+            and not authentication.credentials
+        ):
+            return
+
+        await super().set_info(task_id, notification_config, context)
+
+
+def rewrite_jsonrpc_request_payload(payload: dict[str, object]) -> dict[str, object]:
+    if payload.get('method') != 'CreateTaskPushNotificationConfig':
+        return payload
+
+    params = payload.get('params')
+    if not isinstance(params, dict) or 'config' not in params:
+        return payload
+
+    config = params.get('config')
+    if not isinstance(config, dict):
+        return payload
+
+    rewritten_payload = dict(payload)
+    rewritten_params = dict(params)
+    rewritten_config = dict(config)
+
+    config_id = rewritten_params.pop('configId', None)
+    if isinstance(config_id, str) and config_id and 'id' not in rewritten_config:
+        rewritten_config['id'] = config_id
+
+    if 'auth' in rewritten_config and 'authentication' not in rewritten_config:
+        rewritten_config['authentication'] = rewritten_config.pop('auth')
+
+    rewritten_params.pop('config', None)
+    for key in ('id', 'url', 'token', 'authentication'):
+        if key in rewritten_config and key not in rewritten_params:
+            rewritten_params[key] = rewritten_config[key]
+
+    rewritten_payload['params'] = rewritten_params
+    return rewritten_payload
+
+
+def build_go_compat_push_config(payload: dict[str, object]) -> dict[str, object]:
+    if 'config' in payload and isinstance(payload['config'], dict):
+        return payload
+
+    config: dict[str, object] = {}
+    for key in ('id', 'url', 'token', 'authentication'):
+        if key in payload:
+            config[key] = payload[key]
+    if 'auth' in payload and 'authentication' not in config:
+        config['authentication'] = payload['auth']
+
+    return {
+        'taskId': payload.get('taskId', ''),
+        'config': config,
+    }
+
+
+def build_go_compat_push_config_list(payload: object) -> list[dict[str, object]]:
+    if isinstance(payload, dict):
+        configs = payload.get('configs', [])
+    elif isinstance(payload, list):
+        configs = payload
+    else:
+        configs = []
+
+    compat_configs: list[dict[str, object]] = []
+    if not isinstance(configs, list):
+        return compat_configs
+
+    for entry in configs:
+        if isinstance(entry, dict):
+            compat_configs.append(build_go_compat_push_config(entry))
+
+    return compat_configs
+
+
+def rewrite_jsonrpc_response_payload(method: str, payload: dict[str, object]) -> dict[str, object]:
+    rewritten_payload = dict(payload)
+
+    error = rewritten_payload.get('error')
+    if isinstance(error, dict) and isinstance(error.get('data'), str):
+        rewritten_error = dict(error)
+        rewritten_error['data'] = {'detail': rewritten_error['data']}
+        rewritten_payload['error'] = rewritten_error
+        return rewritten_payload
+
+    if 'error' in rewritten_payload:
+        return rewritten_payload
+
+    result = rewritten_payload.get('result')
+    if method in {'CreateTaskPushNotificationConfig', 'GetTaskPushNotificationConfig'}:
+        if isinstance(result, dict):
+            rewritten_payload['result'] = build_go_compat_push_config(result)
+        return rewritten_payload
+
+    if method == 'ListTaskPushNotificationConfigs':
+        rewritten_payload['result'] = build_go_compat_push_config_list(result)
+
+    return rewritten_payload
+
+
+def rewrite_rest_push_config_payload(payload: dict[str, object]) -> dict[str, object]:
+    if 'config' not in payload or not isinstance(payload['config'], dict):
+        return payload
+
+    rewritten_payload = dict(payload)
+    rewritten_config = dict(rewritten_payload.pop('config'))
+    config_id = rewritten_payload.pop('configId', None)
+    if isinstance(config_id, str) and config_id and 'id' not in rewritten_config:
+        rewritten_config['id'] = config_id
+    if 'auth' in rewritten_config and 'authentication' not in rewritten_config:
+        rewritten_config['authentication'] = rewritten_config.pop('auth')
+    for key in ('id', 'url', 'token', 'authentication'):
+        if key in rewritten_config and key not in rewritten_payload:
+            rewritten_payload[key] = rewritten_config[key]
+    return rewritten_payload
+
+
+def clone_request_with_body(request: Request, body: bytes) -> Request:
+    scope = dict(request.scope)
+    headers = [
+        (key, value)
+        for key, value in request.scope.get('headers', [])
+        if key.lower() != b'content-length'
+    ]
+    headers.append((b'content-length', str(len(body)).encode()))
+    scope['headers'] = headers
+
+    sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal sent
+        if sent:
+            return {'type': 'http.request', 'body': b'', 'more_body': False}
+        sent = True
+        return {'type': 'http.request', 'body': body, 'more_body': False}
+
+    return Request(scope, receive)
+
+
+async def read_response_body(response: Response) -> bytes:
+    body = getattr(response, 'body', None)
+    if isinstance(body, bytes):
+        return body
+
+    chunks: list[bytes] = []
+    async for chunk in response.body_iterator:
+        if isinstance(chunk, bytes):
+            chunks.append(chunk)
+        else:
+            chunks.append(chunk.encode())
+    return b''.join(chunks)
+
+
+def forward_response_headers(response: Response) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in response.headers.items()
+        if key.lower() not in {'content-length', 'content-type'}
+    }
+
+
+def create_jsonrpc_routes_with_compat(request_handler: LegacyRequestHandler) -> list[Route]:
+    dispatcher = JsonRpcDispatcher(request_handler=request_handler)
+
+    async def endpoint(request: Request) -> Response:
+        body = await request.body()
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return await dispatcher.handle_requests(clone_request_with_body(request, body))
+
+        method = ''
+        rewritten_payload = payload
+        if isinstance(payload, dict):
+            method = str(payload.get('method') or '')
+            rewritten_payload = rewrite_jsonrpc_request_payload(payload)
+
+        rewritten_body = body
+        if rewritten_payload is not payload:
+            rewritten_body = json.dumps(rewritten_payload).encode('utf-8')
+
+        response = await dispatcher.handle_requests(
+            clone_request_with_body(request, rewritten_body)
+        )
+        if method not in JSONRPC_PUSH_COMPAT_METHODS:
+            return response
+
+        response_body = await read_response_body(response)
+        if not response_body:
+            return response
+
+        try:
+            response_payload = json.loads(response_body)
+        except json.JSONDecodeError:
+            return response
+
+        rewritten_response_payload = rewrite_jsonrpc_response_payload(
+            method,
+            response_payload,
+        )
+        return JSONResponse(
+            rewritten_response_payload,
+            status_code=response.status_code,
+            headers=forward_response_headers(response),
+        )
+
+    return [Route(path='/rpc', endpoint=endpoint, methods=['POST'])]
+
+
+def create_rest_routes_with_compat(request_handler: LegacyRequestHandler) -> list[Route]:
+    rest_routes = create_rest_routes(request_handler=request_handler)
+    context_builder = DefaultServerCallContextBuilder()
+
+    def build_context(request: Request) -> ServerCallContext:
+        context = context_builder.build(request)
+        if 'tenant' in request.path_params:
+            context.tenant = request.path_params['tenant']
+        return context
+
+    async def create_push_config_endpoint(request: Request) -> Response:
+        params = a2a_pb2.TaskPushNotificationConfig(task_id=request.path_params['id'])
+        body = await request.body()
+        if body:
+            payload = json.loads(body)
+            if isinstance(payload, dict):
+                ParseDict(rewrite_rest_push_config_payload(payload), params)
+        response = await request_handler.on_create_task_push_notification_config(
+            params,
+            build_context(request),
+        )
+        return JSONResponse(
+            content=build_go_compat_push_config(
+                MessageToDict(response, preserving_proto_field_name=False)
+            )
+        )
+
+    async def get_push_config_endpoint(request: Request) -> Response:
+        response = await request_handler.on_get_task_push_notification_config(
+            a2a_pb2.GetTaskPushNotificationConfigRequest(
+                task_id=request.path_params['id'],
+                id=request.path_params['push_id'],
+            ),
+            build_context(request),
+        )
+        return JSONResponse(
+            content=build_go_compat_push_config(
+                MessageToDict(response, preserving_proto_field_name=False)
+            )
+        )
+
+    async def list_push_configs_endpoint(request: Request) -> Response:
+        params = a2a_pb2.ListTaskPushNotificationConfigsRequest(
+            task_id=request.path_params['id']
+        )
+        page_size = request.query_params.get('pageSize')
+        if page_size:
+            params.page_size = int(page_size)
+        page_token = request.query_params.get('pageToken')
+        if page_token:
+            params.page_token = page_token
+        response = await request_handler.on_list_task_push_notification_configs(
+            params,
+            build_context(request),
+        )
+        return JSONResponse(
+            content=build_go_compat_push_config_list(
+                MessageToDict(response, preserving_proto_field_name=False)
+            )
+        )
+
+    async def delete_push_config_endpoint(request: Request) -> Response:
+        await request_handler.on_delete_task_push_notification_config(
+            a2a_pb2.DeleteTaskPushNotificationConfigRequest(
+                task_id=request.path_params['id'],
+                id=request.path_params['push_id'],
+            ),
+            build_context(request),
+        )
+        return JSONResponse(content={})
+
+    async def list_tasks_endpoint(request: Request) -> Response:
+        params = a2a_pb2.ListTasksRequest()
+
+        context_id = request.query_params.get('contextId')
+        if context_id:
+            params.context_id = context_id
+
+        status = request.query_params.get('status')
+        if status:
+            ParseDict({'status': status}, params)
+
+        page_size = request.query_params.get('pageSize')
+        if page_size:
+            params.page_size = int(page_size)
+
+        page_token = request.query_params.get('pageToken')
+        if page_token:
+            params.page_token = page_token
+
+        history_length = request.query_params.get('historyLength')
+        if history_length:
+            params.history_length = int(history_length)
+
+        include_artifacts = request.query_params.get('includeArtifacts')
+        if include_artifacts is not None:
+            params.include_artifacts = include_artifacts.lower() == 'true'
+
+        response = await request_handler.on_list_tasks(params, build_context(request))
+        return JSONResponse(
+            content=MessageToDict(
+                response,
+                preserving_proto_field_name=False,
+                always_print_fields_with_no_presence=True,
+            )
+        )
+
+    return [
+        Route(path='/tasks/{id}/pushNotificationConfigs', endpoint=create_push_config_endpoint, methods=['POST']),
+        Route(path='/tasks/{id}/pushNotificationConfigs', endpoint=list_push_configs_endpoint, methods=['GET']),
+        Route(path='/tasks/{id}/pushNotificationConfigs/{push_id}', endpoint=get_push_config_endpoint, methods=['GET']),
+        Route(path='/tasks/{id}/pushNotificationConfigs/{push_id}', endpoint=delete_push_config_endpoint, methods=['DELETE']),
+        Route(path='/tasks', endpoint=list_tasks_endpoint, methods=['GET']),
+        *rest_routes,
+    ]
+
+
+class InteropExecutor(AgentExecutor):
+    """Implements the scenario matrix used by the shared interop behaviors."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        request_text = get_message_text(context.message) if context.message else ''
+
+        if request_text == MESSAGE_ONLY_REQUEST_TEXT:
+            await event_queue.enqueue_event(
+                a2a_pb2.Message(
+                    role=a2a_pb2.Role.ROLE_AGENT,
+                    message_id=str(uuid4()),
+                    parts=[build_text_part(f'{SERVER_PREFIX} server message-only response')],
+                )
+            )
+            return
+
+        if request_text == TASK_FAILURE_REQUEST_TEXT:
+            await event_queue.enqueue_event(
+                build_task(
+                    context,
+                    a2a_pb2.TaskState.TASK_STATE_FAILED,
+                    f'{SERVER_PREFIX} server failed task',
+                )
+            )
+            return
+
+        if request_text == MULTI_TURN_START_REQUEST_TEXT:
+            await event_queue.enqueue_event(
+                build_task(
+                    context,
+                    a2a_pb2.TaskState.TASK_STATE_INPUT_REQUIRED,
+                    f'{SERVER_PREFIX} server needs more input',
+                )
+            )
+            return
+
+        if request_text == MULTI_TURN_CONTINUE_REQUEST_TEXT:
+            await event_queue.enqueue_event(
+                build_task(
+                    context,
+                    a2a_pb2.TaskState.TASK_STATE_COMPLETED,
+                    f'{SERVER_PREFIX} server multi-turn completed',
+                )
+            )
+            return
+
+        if request_text == STREAMING_REQUEST_TEXT:
+            working_task = build_task(
+                context,
+                a2a_pb2.TaskState.TASK_STATE_WORKING,
+                f'{SERVER_PREFIX} server streaming started',
+            )
+            await event_queue.enqueue_event(working_task)
+
+            artifact_id = str(uuid4())
+            await event_queue.enqueue_event(
+                a2a_pb2.TaskArtifactUpdateEvent(
+                    task_id=working_task.id,
+                    context_id=working_task.context_id,
+                    artifact=a2a_pb2.Artifact(
+                        artifact_id=artifact_id,
+                        parts=[build_text_part('streaming chunk 1')],
+                    ),
+                )
+            )
+            await event_queue.enqueue_event(
+                a2a_pb2.TaskArtifactUpdateEvent(
+                    task_id=working_task.id,
+                    context_id=working_task.context_id,
+                    artifact=a2a_pb2.Artifact(
+                        artifact_id=artifact_id,
+                        parts=[build_text_part('streaming chunk 2')],
+                    ),
+                    append=True,
+                )
+            )
+            await event_queue.enqueue_event(
+                build_status_update(
+                    working_task.id,
+                    working_task.context_id,
+                    a2a_pb2.TaskState.TASK_STATE_COMPLETED,
+                    f'{SERVER_PREFIX} server streaming complete',
+                )
+            )
+            return
+
+        if request_text == LONG_RUNNING_REQUEST_TEXT:
+            working_task = build_task(
+                context,
+                a2a_pb2.TaskState.TASK_STATE_WORKING,
+                f'{SERVER_PREFIX} server long-running started',
+            )
+            await event_queue.enqueue_event(working_task)
+            await asyncio.sleep(0.15)
+            await event_queue.enqueue_event(
+                build_status_update(
+                    working_task.id,
+                    working_task.context_id,
+                    a2a_pb2.TaskState.TASK_STATE_WORKING,
+                    f'{SERVER_PREFIX} server long-running progress',
+                )
+            )
+            await asyncio.sleep(0.15)
+            await event_queue.enqueue_event(
+                build_status_update(
+                    working_task.id,
+                    working_task.context_id,
+                    a2a_pb2.TaskState.TASK_STATE_COMPLETED,
+                    f'{SERVER_PREFIX} server long-running complete',
+                )
+            )
+            return
+
+        if request_text == DATA_TYPES_REQUEST_TEXT:
+            task = build_task(
+                context,
+                a2a_pb2.TaskState.TASK_STATE_COMPLETED,
+                f'{SERVER_PREFIX} server data-types ready',
+            )
+            task.artifacts.append(build_data_types_artifact())
+            await event_queue.enqueue_event(task)
+            return
+
+        state = a2a_pb2.TaskState.TASK_STATE_COMPLETED
+        if request_text == PENDING_REQUEST_TEXT:
+            state = a2a_pb2.TaskState.TASK_STATE_WORKING
+        await event_queue.enqueue_event(
+            build_task(
+                context,
+                state,
+                f'{SERVER_PREFIX} server received: {request_text}',
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        task_id = ''
+        context_id = ''
+        if context.current_task is not None:
+            task_id = context.current_task.id
+            context_id = context.current_task.context_id
+        if context.task_id:
+            task_id = context.task_id
+        if context.context_id:
+            context_id = context.context_id
+
+        if not task_id:
+            raise RuntimeError('task_id is required for cancellation')
+
+        await event_queue.enqueue_event(
+            build_status_update(
+                task_id,
+                context_id,
+                a2a_pb2.TaskState.TASK_STATE_CANCELED,
+                f'{SERVER_PREFIX} server canceled task',
+            )
+        )
+
+
+def build_app(port: int, protocol: str) -> Starlette:
+    base_url = f'http://127.0.0.1:{port}'
+    public_card = build_agent_card(base_url, protocol, extended=False)
+    extended_card = build_agent_card(base_url, protocol, extended=True)
+    request_handler = LegacyRequestHandler(
+        agent_executor=InteropExecutor(),
+        task_store=InMemoryTaskStore(),
+        push_config_store=InteropPushNotificationConfigStore(),
+        agent_card=public_card,
+        extended_agent_card=extended_card,
+    )
+
+    routes = [
+        *create_agent_card_routes(public_card, card_url=AGENT_CARD_WELL_KNOWN_PATH),
+    ]
+    if protocol == 'rest':
+        routes.extend(create_rest_routes_with_compat(request_handler))
+    else:
+        routes.extend(create_jsonrpc_routes_with_compat(request_handler))
+
+    return Starlette(routes=routes)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Run the Python A2A interop fixture server.')
+    parser.add_argument('--port', type=int, required=True)
+    parser.add_argument('--protocol', choices=('jsonrpc', 'rest'), required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    args = parse_args()
+    app = build_app(args.port, args.protocol)
+    LOGGER.info('python %s fixture listening on http://127.0.0.1:%d', args.protocol, args.port)
+    uvicorn.run(
+        app,
+        host='127.0.0.1',
+        port=args.port,
+        access_log=False,
+        log_level='warning',
+        lifespan='off',
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/integrations/agntcy-a2a/fixtures/python/requirements.txt
+++ b/integrations/agntcy-a2a/fixtures/python/requirements.txt
@@ -1,0 +1,7 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# The Python interop fixture intentionally tracks the v1.0 release branch the
+# suite is validating rather than the stable 0.3 line.
+a2a-sdk[http-server] @ git+https://github.com/a2aproject/a2a-python.git@release-please--branches--1.0-dev
+uvicorn>=0.35.0

--- a/integrations/agntcy-a2a/tests/interop_behaviors_test.go
+++ b/integrations/agntcy-a2a/tests/interop_behaviors_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -345,6 +346,37 @@ func (harness dotNetProbeHarness) AssertScenarioParity(ctx context.Context, targ
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), output)
 }
 
+type pythonProbeHarness struct {
+	getAssets func() pythonFixtureAssets
+	options   rustProbeOptions
+}
+
+func (harness pythonProbeHarness) optionsForScenario(scenario probeScenario) rustProbeOptions {
+	options := harness.options
+	options.scenario = scenario
+	return options
+}
+
+func (harness pythonProbeHarness) AssertUnaryStreaming(ctx context.Context, target interopTarget) {
+	output, err := runPythonProbe(ctx, harness.getAssets(), target.baseURL, target.serverPrefix, harness.optionsForScenario(probeScenarioUnaryStreaming))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), output)
+}
+
+func (harness pythonProbeHarness) AssertTaskLifecycle(ctx context.Context, target interopTarget) {
+	output, err := runPythonProbe(ctx, harness.getAssets(), target.baseURL, target.serverPrefix, harness.optionsForScenario(probeScenarioTaskLifecycle))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), output)
+}
+
+func (harness pythonProbeHarness) AssertPushConfig(ctx context.Context, target interopTarget) {
+	output, err := runPythonProbe(ctx, harness.getAssets(), target.baseURL, target.serverPrefix, harness.optionsForScenario(probeScenarioPushConfig))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), output)
+}
+
+func (harness pythonProbeHarness) AssertScenarioParity(ctx context.Context, target interopTarget) {
+	output, err := runPythonProbe(ctx, harness.getAssets(), target.baseURL, target.serverPrefix, harness.optionsForScenario(probeScenarioParity))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), output)
+}
+
 func newGoClient(ctx context.Context, baseURL string) (*a2aclient.Client, error) {
 	card, err := agentcard.DefaultResolver.Resolve(ctx, baseURL)
 	if err != nil {
@@ -629,7 +661,12 @@ func goClientAssertTaskLifecycle(ctx context.Context, client *a2aclient.Client, 
 	gomega.Expect(fetchedCanceledText).To(gomega.Equal(expectedCancelText(serverPrefix)))
 
 	_, err = client.GetTask(ctx, &a2a.GetTaskRequest{ID: a2a.NewTaskID()})
-	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("task not found")))
+	gomega.Expect(err).To(gomega.WithTransform(func(err error) string {
+		if err == nil {
+			return ""
+		}
+		return strings.ToLower(err.Error())
+	}, gomega.ContainSubstring("task not found")))
 
 	_, err = client.CancelTask(ctx, &a2a.CancelTaskRequest{ID: completedTask.ID})
 	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("cancel")))

--- a/integrations/agntcy-a2a/tests/interop_launchers_test.go
+++ b/integrations/agntcy-a2a/tests/interop_launchers_test.go
@@ -16,7 +16,41 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
+
+func buildGoFixture(root string, outputPath string) error {
+	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
+	defer cancel()
+
+	goBuild := exec.CommandContext(buildCtx, "go", "build", "-o", outputPath, "./fixtures/go-jsonrpc-server")
+	goBuild.Dir = root
+	if output, err := goBuild.CombinedOutput(); err != nil {
+		return fmt.Errorf("build go fixture: %w\n%s", err, string(output))
+	}
+
+	return nil
+}
+
+func buildGoFixtureBinaryOnly() (fixtureBinaries, error) {
+	root := componentRoot()
+	tempDir, err := os.MkdirTemp("", "agntcy-a2a-go-")
+	if err != nil {
+		return fixtureBinaries{}, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	binaries := fixtureBinaries{
+		tempDir:  tempDir,
+		goServer: filepath.Join(tempDir, executableName("go-jsonrpc-server")),
+	}
+
+	if err := buildGoFixture(root, binaries.goServer); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return fixtureBinaries{}, err
+	}
+
+	return binaries, nil
+}
 
 func buildFixtureBinaries() (fixtureBinaries, error) {
 	root := componentRoot()
@@ -31,16 +65,13 @@ func buildFixtureBinaries() (fixtureBinaries, error) {
 		rustServer: filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-server")),
 		rustProbe:  filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-probe")),
 	}
+	if err := buildGoFixture(root, binaries.goServer); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return fixtureBinaries{}, err
+	}
 
 	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
 	defer cancel()
-
-	goBuild := exec.CommandContext(buildCtx, "go", "build", "-o", binaries.goServer, "./fixtures/go-jsonrpc-server")
-	goBuild.Dir = root
-	if output, err := goBuild.CombinedOutput(); err != nil {
-		_ = os.RemoveAll(tempDir)
-		return fixtureBinaries{}, fmt.Errorf("build go fixture: %w\n%s", err, string(output))
-	}
 
 	rustBuild := exec.CommandContext(
 		buildCtx,
@@ -59,6 +90,91 @@ func buildFixtureBinaries() (fixtureBinaries, error) {
 	}
 
 	return binaries, nil
+}
+
+func venvPythonCommand(venvDir string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(venvDir, "Scripts", executableName("python"))
+	}
+
+	return filepath.Join(venvDir, "bin", executableName("python"))
+}
+
+func validatePythonCommand(path string) error {
+	cmd := exec.Command(path, "-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("validate python executable %s: %w\n%s", path, err, string(output))
+	}
+
+	return nil
+}
+
+func resolvePythonCommand() (string, error) {
+	if configured := os.Getenv("PYTHON"); configured != "" {
+		if err := validatePythonCommand(configured); err != nil {
+			return "", fmt.Errorf("validate configured PYTHON: %w", err)
+		}
+		return configured, nil
+	}
+
+	for _, candidate := range []string{"python3.13", "python3.12", "python3.11", "python3.10", "python3"} {
+		path, err := exec.LookPath(candidate)
+		if err != nil {
+			continue
+		}
+		if err := validatePythonCommand(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", errors.New("python 3.10+ executable not found; install Python 3.10+ or set PYTHON to its path")
+}
+
+func buildPythonFixtureAssets() (pythonFixtureAssets, error) {
+	root := componentRoot()
+	pythonCommand, err := resolvePythonCommand()
+	if err != nil {
+		return pythonFixtureAssets{}, err
+	}
+
+	tempDir, err := os.MkdirTemp("", "agntcy-a2a-python-")
+	if err != nil {
+		return pythonFixtureAssets{}, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	venvDir := filepath.Join(tempDir, "venv")
+	buildCtx, cancel := context.WithTimeout(context.Background(), 2*buildTimeout)
+	defer cancel()
+
+	createVenv := exec.CommandContext(buildCtx, pythonCommand, "-m", "venv", venvDir)
+	createVenv.Dir = root
+	if output, err := createVenv.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return pythonFixtureAssets{}, fmt.Errorf("create python fixture venv: %w\n%s", err, string(output))
+	}
+
+	venvPython := venvPythonCommand(venvDir)
+	installRequirements := exec.CommandContext(
+		buildCtx,
+		venvPython,
+		"-m",
+		"pip",
+		"install",
+		"-r",
+		filepath.Join(root, "fixtures", "python", "requirements.txt"),
+	)
+	installRequirements.Dir = root
+	if output, err := installRequirements.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return pythonFixtureAssets{}, fmt.Errorf("install python fixture requirements: %w\n%s", err, string(output))
+	}
+
+	return pythonFixtureAssets{
+		tempDir:       tempDir,
+		pythonCommand: venvPython,
+		serverScript:  filepath.Join(root, "fixtures", "python", "interop_python_server.py"),
+		probeScript:   filepath.Join(root, "fixtures", "python", "interop_python_probe.py"),
+	}, nil
 }
 
 func resolveDotNetCommand() (string, error) {
@@ -260,6 +376,30 @@ func startDotNetFixture(binaries rustDotNetFixtureBinaries, port int, protocol t
 	return process, baseURL, nil
 }
 
+func startPythonFixture(assets pythonFixtureAssets, port int, protocol transportProtocol) (*fixtureProcess, string, error) {
+	if protocol == transportGRPC {
+		return nil, "", errors.New("python fixture does not support gRPC yet")
+	}
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	process, err := startFixtureProcess(
+		fmt.Sprintf("python-%s-server", protocol),
+		componentRoot(),
+		baseURL+"/.well-known/agent-card.json",
+		assets.pythonCommand,
+		assets.serverScript,
+		"--port",
+		fmt.Sprintf("%d", port),
+		"--protocol",
+		string(protocol),
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return process, baseURL, nil
+}
+
 func appendProbeOptions(args []string, options rustProbeOptions) []string {
 	if options.scenario != "" {
 		args = append(args, "--scenario", string(options.scenario))
@@ -328,6 +468,31 @@ func runDotNetProbe(
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("dotnet probe failed: %w\n%s", err, string(output))
+	}
+
+	return string(output), nil
+}
+
+func runPythonProbe(
+	ctx context.Context,
+	assets pythonFixtureAssets,
+	baseURL string,
+	serverPrefix string,
+	options rustProbeOptions,
+) (string, error) {
+	args := append([]string{assets.probeScript}, appendProbeOptions([]string{
+		"--card-url",
+		baseURL,
+		"--server-prefix",
+		serverPrefix,
+	}, options)...)
+
+	cmd := exec.CommandContext(ctx, assets.pythonCommand, args...)
+	cmd.Dir = componentRoot()
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("python probe failed: %w\n%s", err, string(output))
 	}
 
 	return string(output), nil

--- a/integrations/agntcy-a2a/tests/interop_launchers_test.go
+++ b/integrations/agntcy-a2a/tests/interop_launchers_test.go
@@ -32,6 +32,28 @@ func buildGoFixture(root string, outputPath string) error {
 	return nil
 }
 
+func buildRustFixtures(root string, targetDir string) error {
+	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
+	defer cancel()
+
+	rustBuild := exec.CommandContext(
+		buildCtx,
+		"cargo",
+		"build",
+		"--manifest-path",
+		filepath.Join(root, "fixtures", "rust", "Cargo.toml"),
+		"--bins",
+		"--target-dir",
+		targetDir,
+	)
+	rustBuild.Dir = root
+	if output, err := rustBuild.CombinedOutput(); err != nil {
+		return fmt.Errorf("build rust fixtures: %w\n%s", err, string(output))
+	}
+
+	return nil
+}
+
 func buildGoFixtureBinaryOnly() (fixtureBinaries, error) {
 	root := componentRoot()
 	tempDir, err := os.MkdirTemp("", "agntcy-a2a-go-")
@@ -45,6 +67,27 @@ func buildGoFixtureBinaryOnly() (fixtureBinaries, error) {
 	}
 
 	if err := buildGoFixture(root, binaries.goServer); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return fixtureBinaries{}, err
+	}
+
+	return binaries, nil
+}
+
+func buildRustFixtureBinaryOnly() (fixtureBinaries, error) {
+	root := componentRoot()
+	tempDir, err := os.MkdirTemp("", "agntcy-a2a-rust-")
+	if err != nil {
+		return fixtureBinaries{}, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	binaries := fixtureBinaries{
+		tempDir:    tempDir,
+		rustServer: filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-server")),
+		rustProbe:  filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-probe")),
+	}
+
+	if err := buildRustFixtures(root, filepath.Join(tempDir, "cargo-target")); err != nil {
 		_ = os.RemoveAll(tempDir)
 		return fixtureBinaries{}, err
 	}
@@ -69,24 +112,9 @@ func buildFixtureBinaries() (fixtureBinaries, error) {
 		_ = os.RemoveAll(tempDir)
 		return fixtureBinaries{}, err
 	}
-
-	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
-	defer cancel()
-
-	rustBuild := exec.CommandContext(
-		buildCtx,
-		"cargo",
-		"build",
-		"--manifest-path",
-		filepath.Join(root, "fixtures", "rust", "Cargo.toml"),
-		"--bins",
-		"--target-dir",
-		filepath.Join(tempDir, "cargo-target"),
-	)
-	rustBuild.Dir = root
-	if output, err := rustBuild.CombinedOutput(); err != nil {
+	if err := buildRustFixtures(root, filepath.Join(tempDir, "cargo-target")); err != nil {
 		_ = os.RemoveAll(tempDir)
-		return fixtureBinaries{}, fmt.Errorf("build rust fixtures: %w\n%s", err, string(output))
+		return fixtureBinaries{}, err
 	}
 
 	return binaries, nil
@@ -230,20 +258,9 @@ func buildRustDotNetFixtureBinaries() (rustDotNetFixtureBinaries, error) {
 	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
 	defer cancel()
 
-	rustBuild := exec.CommandContext(
-		buildCtx,
-		"cargo",
-		"build",
-		"--manifest-path",
-		filepath.Join(root, "fixtures", "rust", "Cargo.toml"),
-		"--bins",
-		"--target-dir",
-		filepath.Join(tempDir, "cargo-target"),
-	)
-	rustBuild.Dir = root
-	if output, err := rustBuild.CombinedOutput(); err != nil {
+	if err := buildRustFixtures(root, filepath.Join(tempDir, "cargo-target")); err != nil {
 		_ = os.RemoveAll(tempDir)
-		return rustDotNetFixtureBinaries{}, fmt.Errorf("build rust fixtures: %w\n%s", err, string(output))
+		return rustDotNetFixtureBinaries{}, err
 	}
 
 	dotnetServerBuild := exec.CommandContext(

--- a/integrations/agntcy-a2a/tests/interop_python_go_test.go
+++ b/integrations/agntcy-a2a/tests/interop_python_go_test.go
@@ -1,0 +1,102 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+// This file is the Python/Go suite wrapper. It declares the Python v1.0 fixture environment,
+// the Go fixture binaries reused in this slice, and the client/server matrix for JSON-RPC and
+// HTTP+JSON coverage.
+// To expand Python coverage, change the matrix data here and keep the cross-SDK behavior logic in
+// interop_behaviors_test.go so the shared slices remain authored once.
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("A2A Python and Go interoperability", ginkgo.Ordered, ginkgo.Label("suite-python-go"), func() {
+	var (
+		goAssets             fixtureBinaries
+		pythonAssets         pythonFixtureAssets
+		goJSONRPCFixture     *fixtureProcess
+		pythonJSONRPCFixture *fixtureProcess
+		goRESTFixture        *fixtureProcess
+		pythonRESTFixture    *fixtureProcess
+		goJSONRPCFixtureURL  string
+		pythonJSONRPCURL     string
+		goRESTFixtureURL     string
+		pythonRESTURL        string
+	)
+
+	goClient := goSDKHarness{}
+	pythonClient := pythonProbeHarness{
+		getAssets: func() pythonFixtureAssets { return pythonAssets },
+		options: rustProbeOptions{
+			expectPushSupported: true,
+		},
+	}
+	clients := []interopClientMatrixSpec{
+		{label: "go", displayName: "Go", harness: goClient},
+		{label: "python", displayName: "Python", harness: pythonClient},
+	}
+	servers := []interopServerMatrixSpec{
+		{
+			label:               "go",
+			displayName:         "Go",
+			serverPrefix:        "go",
+			expectPushSupported: true,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return goJSONRPCFixtureURL },
+				transportREST:    func() string { return goRESTFixtureURL },
+			},
+		},
+		{
+			label:               "python",
+			displayName:         "Python",
+			serverPrefix:        "python",
+			expectPushSupported: true,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return pythonJSONRPCURL },
+				transportREST:    func() string { return pythonRESTURL },
+			},
+		},
+	}
+
+	ginkgo.BeforeAll(func() {
+		var err error
+
+		goAssets, err = buildGoFixtureBinaryOnly()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonAssets, err = buildPythonFixtureAssets()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		goJSONRPCFixture, goJSONRPCFixtureURL, err = startGoFixture(goAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonJSONRPCFixture, pythonJSONRPCURL, err = startPythonFixture(pythonAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		goRESTFixture, goRESTFixtureURL, err = startGoFixture(goAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonRESTFixture, pythonRESTURL, err = startPythonFixture(pythonAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterAll(func() {
+		stopFixtureIfRunning(pythonRESTFixture)
+		stopFixtureIfRunning(goRESTFixture)
+		stopFixtureIfRunning(pythonJSONRPCFixture)
+		stopFixtureIfRunning(goJSONRPCFixture)
+		removeTempDir(pythonAssets.tempDir)
+		removeTempDir(goAssets.tempDir)
+	})
+
+	registerInteropTransportMatrix(
+		[]transportProtocol{transportJSONRPC, transportREST},
+		clients,
+		servers,
+		nil,
+	)
+})

--- a/integrations/agntcy-a2a/tests/interop_rust_python_test.go
+++ b/integrations/agntcy-a2a/tests/interop_rust_python_test.go
@@ -1,0 +1,105 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+// This file is the Rust/Python suite wrapper. It keeps the matrix declaration,
+// fixture lifecycle, and transport coverage local to this slice while reusing
+// the shared Go-authored behavior assertions.
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("A2A Rust and Python interoperability", ginkgo.Ordered, ginkgo.Label("suite-rust-python"), func() {
+	var (
+		rustAssets           fixtureBinaries
+		pythonAssets         pythonFixtureAssets
+		rustJSONRPCFixture   *fixtureProcess
+		pythonJSONRPCFixture *fixtureProcess
+		rustRESTFixture      *fixtureProcess
+		pythonRESTFixture    *fixtureProcess
+		rustJSONRPCURL       string
+		pythonJSONRPCURL     string
+		rustRESTURL          string
+		pythonRESTURL        string
+	)
+
+	rustClient := rustProbeHarness{
+		getBinaries: func() fixtureBinaries { return rustAssets },
+		options: rustProbeOptions{
+			expectPushSupported: true,
+		},
+	}
+	pythonClient := pythonProbeHarness{
+		getAssets: func() pythonFixtureAssets { return pythonAssets },
+		options: rustProbeOptions{
+			expectPushSupported: true,
+		},
+	}
+	clients := []interopClientMatrixSpec{
+		{label: "rust", displayName: "Rust", harness: rustClient},
+		{label: "python", displayName: "Python", harness: pythonClient},
+	}
+	servers := []interopServerMatrixSpec{
+		{
+			label:               "rust",
+			displayName:         "Rust",
+			serverPrefix:        "rust",
+			expectPushSupported: true,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return rustJSONRPCURL },
+				transportREST:    func() string { return rustRESTURL },
+			},
+		},
+		{
+			label:               "python",
+			displayName:         "Python",
+			serverPrefix:        "python",
+			expectPushSupported: true,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return pythonJSONRPCURL },
+				transportREST:    func() string { return pythonRESTURL },
+			},
+		},
+	}
+
+	ginkgo.BeforeAll(func() {
+		var err error
+
+		rustAssets, err = buildRustFixtureBinaryOnly()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonAssets, err = buildPythonFixtureAssets()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		rustJSONRPCFixture, rustJSONRPCURL, err = startRustFixture(rustAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonJSONRPCFixture, pythonJSONRPCURL, err = startPythonFixture(pythonAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		rustRESTFixture, rustRESTURL, err = startRustFixture(rustAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonRESTFixture, pythonRESTURL, err = startPythonFixture(pythonAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterAll(func() {
+		stopFixtureIfRunning(pythonRESTFixture)
+		stopFixtureIfRunning(rustRESTFixture)
+		stopFixtureIfRunning(pythonJSONRPCFixture)
+		stopFixtureIfRunning(rustJSONRPCFixture)
+		removeTempDir(pythonAssets.tempDir)
+		removeTempDir(rustAssets.tempDir)
+	})
+
+	registerInteropTransportMatrix(
+		[]transportProtocol{transportJSONRPC, transportREST},
+		clients,
+		servers,
+		nil,
+	)
+})

--- a/integrations/agntcy-a2a/tests/interop_shared_test.go
+++ b/integrations/agntcy-a2a/tests/interop_shared_test.go
@@ -97,6 +97,13 @@ type rustDotNetFixtureBinaries struct {
 	dotnetProbeDL  string
 }
 
+type pythonFixtureAssets struct {
+	tempDir       string
+	pythonCommand string
+	serverScript  string
+	probeScript   string
+}
+
 func (binaries rustDotNetFixtureBinaries) rustAssets() fixtureBinaries {
 	return fixtureBinaries{
 		tempDir:    binaries.tempDir,


### PR DESCRIPTION
## Summary
- add a Rust/Python interoperability suite alongside the existing Python/Go coverage in agntcy-a2a
- wire the Python suite tasks into the Taskfiles and GitHub Actions A2A matrix so CI runs both Python/Go and Rust/Python jobs
- fix Python fixture and probe compatibility issues needed for Rust/Python JSON-RPC and HTTP+JSON interop, and document the expanded coverage

## Testing
- go test . -run TestTests -ginkgo.label-filter='suite-rust-python && jsonrpc'
- go test . -run TestTests -ginkgo.label-filter='suite-rust-python && rest'
- task integrations:a2a:test:rust-python
- go test . -run TestTests -ginkgo.label-filter='suite-python-go && jsonrpc' -ginkgo.v
- go test . -run TestTests -ginkgo.label-filter='suite-python-go && rest' -ginkgo.v
