### PR TITLE
feat(agntcy-a2a): add go-dotnet and python-dotnet interop suites

### DIFF
--- a/.github/workflows/test-integrations.yaml
+++ b/.github/workflows/test-integrations.yaml
@@ -296,6 +296,24 @@ jobs:
             go-version: '1.24.4'
             setup-dotnet: 'true'
             dotnet-version: '8.0.x'
+          - id: go-dotnet
+            display-name: Go/C#
+            task: integrations:a2a:test:go-dotnet
+            artifact-name: a2a-interop-test-result-go-dotnet
+            setup-python: 'false'
+            setup-go: 'true'
+            go-version: '1.24.4'
+            setup-dotnet: 'true'
+            dotnet-version: '8.0.x'
+          - id: python-dotnet
+            display-name: Python/C#
+            task: integrations:a2a:test:python-dotnet
+            artifact-name: a2a-interop-test-result-python-dotnet
+            setup-python: 'true'
+            setup-go: 'false'
+            go-version: '1.24.4'
+            setup-dotnet: 'true'
+            dotnet-version: '8.0.x'
 
     name: A2A ${{ matrix.display-name }}
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ task: Available tasks for this project:
 * benchmarks:directory:test:                              All ADS benchmark test
 * benchmarks:slim:test:                                All Slim benchmark test
 * integrations:a2a:test:                                 All A2A interoperability tests
+* integrations:a2a:test:go-dotnet:                       Go and C# interoperability tests
 * integrations:a2a:test:python-go:                       Python and Go interoperability tests
+* integrations:a2a:test:python-dotnet:                   Python and C# interoperability tests
 * integrations:a2a:test:rust-python:                     Rust and Python interoperability tests
 * integrations:a2a:test:rust-go:jsonrpc:                 Rust and Go JSON-RPC interoperability smoke test
 * integrations:a2a:test:rust-go:jsonrpc:go-go:           Go client to Go server JSON-RPC interoperability test
@@ -186,22 +188,26 @@ Go, Rust, .NET, and Python fixtures locally across these suite slices:
 
 - Rust/Go across JSON-RPC, HTTP+JSON, and gRPC
 - Rust/.NET across JSON-RPC and HTTP+JSON
+- Go/.NET across JSON-RPC and HTTP+JSON
 - Python/Go across JSON-RPC and HTTP+JSON
 - Rust/Python across JSON-RPC and HTTP+JSON
+- Python/.NET across JSON-RPC and HTTP+JSON
 
 To run it from the repository root you need:
 
 - [Taskfile](https://taskfile.dev/installation/)
 - [Rust and Cargo](https://www.rust-lang.org/tools/install)
-- [Go](https://go.dev/doc/install) for the Rust/Go and Python/Go slices
-- Python 3.10+ for the Python/Go and Rust/Python slices
-- .NET 8 SDK for the Rust/.NET slice
+- [Go](https://go.dev/doc/install) for the Rust/Go, Python/Go, and Go/.NET slices
+- Python 3.10+ for the Python/Go, Rust/Python, and Python/.NET slices
+- .NET 8 SDK for the Rust/.NET, Go/.NET, and Python/.NET slices
 
 ```bash
 task integrations:a2a:test
 task integrations:a2a:test:rust-go:jsonrpc
+task integrations:a2a:test:go-dotnet
 task integrations:a2a:test:python-go
 task integrations:a2a:test:rust-python
+task integrations:a2a:test:python-dotnet
 task integrations:a2a:test:rust-python:jsonrpc:python-rust
 ```
 

--- a/integrations/agntcy-a2a/README.md
+++ b/integrations/agntcy-a2a/README.md
@@ -4,17 +4,21 @@ This component hosts cross-SDK A2A interoperability checks.
 
 The suite is structured around shared Ginkgo behaviors and per-SDK harnesses. The behavior assertions are written once, expanded across client/server transport matrices, and the language-specific differences are isolated behind Go, Rust, .NET, and Python launchers or probes.
 
-The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC, a Rust/.NET suite across JSON-RPC and HTTP+JSON, and Python v1.0 suites for both Go and Rust across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
+The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC; .NET-backed suites for Rust, Go, and Python across JSON-RPC and HTTP+JSON; and Python v1.0 suites for both Go and Rust across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
 
 All 12 Rust/Go client-server legs are green across JSON-RPC, HTTP+JSON, and gRPC. The Go and Rust fixtures expose push-config CRUD, and CSIT validates that path from both clients against both server targets across all three transports.
 
 The Rust/.NET suite reuses the existing Rust fixture and Rust probe, adds CSIT-owned .NET fixture and probe binaries, and covers 8 legs: 4 JSON-RPC legs (`dotnet-dotnet`, `dotnet-rust`, `rust-dotnet`, `rust-rust-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
+The Go/.NET suite reuses the existing Go fixture with the same CSIT-owned .NET fixture and probe binaries, and covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-dotnet`, `dotnet-go`, `dotnet-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+
 The Python/Go suite adds a CSIT-owned Python server and probe built against the `release-please--branches--1.0-dev` branch of `a2aproject/a2a-python`. It currently covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
 The Rust/Python suite reuses the existing Rust fixture and probe together with the same CSIT-owned Python server and probe. It currently covers 8 legs: 4 JSON-RPC legs (`rust-rust`, `rust-python`, `python-rust`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
-Push-config is covered in the Rust/.NET suite as well, but only the Rust-server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. The default `task test` and `task integrations:a2a:test` entrypoints run the Rust/Go, Rust/.NET, Python/Go, and Rust/Python suites.
+The Python/.NET suite reuses the same CSIT-owned Python server and probe together with the same .NET fixture and probe binaries. It currently covers 8 legs: 4 JSON-RPC legs (`python-python`, `python-dotnet`, `dotnet-python`, `dotnet-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+
+Push-config is covered in the .NET-backed suites as well, but only the non-.NET server legs are expected to support push-config CRUD; the .NET-server legs are expected to return the current unsupported error. The default `task test` and `task integrations:a2a:test` entrypoints run the Rust/Go, Rust/.NET, Go/.NET, Python/Go, Rust/Python, and Python/.NET suites.
 
 Across the matrix, the scenarios validate the same core interoperability behavior:
 
@@ -37,9 +41,9 @@ Each leg keeps its existing suite, transport, and pair labels for Task targets, 
 
 The gRPC legs follow the same agent-card discovery path as the other transports: each fixture serves `/.well-known/agent-card.json` over HTTP and advertises a separate gRPC transport endpoint from that card.
 
-The Rust/.NET slice currently requires a local `dotnet` CLI for the .NET 8 SDK because the CSIT harness builds the fixture and probe from published `A2A` and `A2A.AspNetCore` NuGet packages at test time.
+The .NET-backed slices currently require a local `dotnet` CLI for the .NET 8 SDK because the CSIT harness builds the fixture and probe from published `A2A` and `A2A.AspNetCore` NuGet packages at test time.
 
-The Python/Go and Rust/Python slices require Python 3.10+ and install the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `release-please--branches--1.0-dev` branch.
+The Python/Go, Rust/Python, and Python/.NET slices require Python 3.10+ and install the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `release-please--branches--1.0-dev` branch.
 
 ## Matrix
 
@@ -51,8 +55,10 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | --- | --- | --- | --- |
 | Rust/Go | ✅ | ✅ | ✅ |
 | Rust/.NET | ✅ | ✅ | ❌ |
+| Go/.NET | ✅ | ✅ | ❌ |
 | Python/Go | ✅ | ✅ | ❌ |
 | Rust/Python | ✅ | ✅ | ❌ |
+| Python/.NET | ✅ | ✅ | ❌ |
 
 ### Rust/Go Leg Coverage
 
@@ -72,6 +78,15 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | Rust -> .NET | ✅ | ✅ | ❌ |
 | Rust -> Rust (Rust/.NET slice) | ✅ | ✅ | ❌ |
 
+### Go/.NET Leg Coverage
+
+| Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
+| --- | --- | --- | --- |
+| Go -> Go (Go/.NET slice) | ✅ | ✅ | ❌ |
+| Go -> .NET | ✅ | ✅ | ❌ |
+| .NET -> Go | ✅ | ✅ | ❌ |
+| .NET -> .NET (Go/.NET slice) | ✅ | ✅ | ❌ |
+
 ### Python/Go Leg Coverage
 
 | Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
@@ -90,30 +105,39 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 | Python -> Rust | ✅ | ✅ | ❌ |
 | Python -> Python (Rust/Python slice) | ✅ | ✅ | ❌ |
 
+### Python/.NET Leg Coverage
+
+| Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
+| --- | --- | --- | --- |
+| Python -> Python (Python/.NET slice) | ✅ | ✅ | ❌ |
+| Python -> .NET | ✅ | ✅ | ❌ |
+| .NET -> Python | ✅ | ✅ | ❌ |
+| .NET -> .NET (Python/.NET slice) | ✅ | ✅ | ❌ |
+
 ### Behavior Coverage
 
-| Behavior | Rust/Go | Rust/.NET | Python/Go | Rust/Python |
-| --- | --- | --- | --- | --- |
-| Unary `SendMessage` | ✅ | ✅ | ✅ | ✅ |
-| Streaming `SendMessage` | ✅ | ✅ | ✅ | ✅ |
-| Message-only response path | ✅ | ✅ | ✅ | ✅ |
-| `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ | ✅ | ✅ |
-| Failed-task response path | ✅ | ✅ | ✅ | ✅ |
-| Multi-turn input-required continuation | ✅ | ✅ | ✅ | ✅ |
-| Long-running completion after non-blocking send | ✅ | ✅ | ✅ | ✅ |
-| Artifact-rich streaming updates | ✅ | ✅ | ✅ | ✅ |
-| Structured text + data + URL artifact payloads | ✅ | ✅ | ✅ | ✅ |
-| Extended-agent-card discovery | ✅ | ✅ | ✅ | ✅ |
-| Extended-card security-scheme metadata | ✅ | ✅ | ✅ | ✅ |
-| Missing-task and non-cancelable-task errors | ✅ | ✅ | ✅ | ✅ |
-| Mixed text + structured-data payload preserved through task history | ✅ | ✅ | ✅ | ✅ |
-| Push-config CRUD against Rust-server targets | ✅ | ✅ | n/a | ✅ |
-| Unsupported push-config response against non-Rust server targets | ✅ | ✅ | n/a | n/a |
-| Push-config CRUD against Go- and Python-server targets where covered | n/a | n/a | ✅ | ✅ |
+| Behavior | Rust/Go | Rust/.NET | Go/.NET | Python/Go | Rust/Python | Python/.NET |
+| --- | --- | --- | --- | --- | --- | --- |
+| Unary `SendMessage` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Streaming `SendMessage` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Message-only response path | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `GetTask`, `ListTasks`, and `CancelTask` lifecycle | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Failed-task response path | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Multi-turn input-required continuation | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Long-running completion after non-blocking send | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Artifact-rich streaming updates | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Structured text + data + URL artifact payloads | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Extended-agent-card discovery | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Extended-card security-scheme metadata where present | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Missing-task and non-cancelable-task errors | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Mixed text + structured-data payload preserved through task history | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Push-config CRUD against Rust-server targets where covered | ✅ | ✅ | n/a | n/a | ✅ | n/a |
+| Unsupported push-config response against .NET-server targets | n/a | ✅ | ✅ | n/a | n/a | ✅ |
+| Push-config CRUD against Go- and Python-server targets where covered | n/a | n/a | ✅ | ✅ | ✅ | ✅ |
 
-For Rust/.NET, the uncovered cells are the current gRPC gap. For push-config, a ✅ means the suite verifies the expected behavior for that leg: CRUD succeeds on Rust-server targets and the current unsupported error is returned on Go-server or .NET-server targets.
+For the .NET-backed slices, the uncovered cells are the current gRPC gap. For push-config, a ✅ means the suite verifies the expected behavior for that leg: CRUD succeeds on supported Go, Rust, or Python server targets, and the current unsupported error is returned on .NET-server targets.
 
-For the .NET-owned fixture specifically, the public and extended cards currently omit `securitySchemes` because the released Rust resolver used by this CSIT slice does not yet accept the .NET SDK's null-filled union encoding for that field. The overall suites still validate bearer-token security metadata against the Rust and Go fixtures.
+For the .NET-owned fixture specifically, the public and extended cards currently omit `securitySchemes` because the released Rust resolver used by this CSIT slice does not yet accept the .NET SDK's null-filled union encoding for that field. The overall suites still validate bearer-token security metadata against the Rust, Go, and Python fixtures where that field is present.
 
 ## Running the Suite
 
@@ -123,11 +147,13 @@ From `integrations/agntcy-a2a/`:
 task test
 task test:rust-go
 task test:rust-dotnet
+task test:go-dotnet
 task test:python-go
 task test:rust-python
+task test:python-dotnet
 ```
 
-`task test` now runs the full `task test:rust-go` transport matrix plus `task test:rust-dotnet`, `task test:python-go`, and `task test:rust-python`.
+`task test` now runs the full `task test:rust-go` transport matrix plus `task test:rust-dotnet`, `task test:go-dotnet`, `task test:python-go`, `task test:rust-python`, and `task test:python-dotnet`.
 
 The user-facing task triggers are organized by scope:
 
@@ -137,8 +163,10 @@ The user-facing task triggers are organized by scope:
 task test
 task test:rust-go
 task test:rust-dotnet
+task test:go-dotnet
 task test:python-go
 task test:rust-python
+task test:python-dotnet
 ```
 
 - Cross-suite behavior slices:
@@ -196,6 +224,26 @@ task test:rust-dotnet:behavior:push-config
 task test:rust-dotnet:behavior:parity
 ```
 
+- Go/.NET suite filters:
+
+```sh
+task test:go-dotnet:jsonrpc
+task test:go-dotnet:rest
+task test:go-dotnet:jsonrpc:go-go
+task test:go-dotnet:jsonrpc:go-dotnet
+task test:go-dotnet:jsonrpc:dotnet-go
+task test:go-dotnet:jsonrpc:dotnet-dotnet
+task test:go-dotnet:rest:go-go
+task test:go-dotnet:rest:go-dotnet
+task test:go-dotnet:rest:dotnet-go
+task test:go-dotnet:rest:dotnet-dotnet
+task test:go-dotnet:behavior:core
+task test:go-dotnet:behavior:unary-streaming
+task test:go-dotnet:behavior:lifecycle
+task test:go-dotnet:behavior:push-config
+task test:go-dotnet:behavior:parity
+```
+
 - Python/Go suite filters:
 
 ```sh
@@ -236,6 +284,26 @@ task test:rust-python:behavior:push-config
 task test:rust-python:behavior:parity
 ```
 
+- Python/.NET suite filters:
+
+```sh
+task test:python-dotnet:jsonrpc
+task test:python-dotnet:rest
+task test:python-dotnet:jsonrpc:python-python
+task test:python-dotnet:jsonrpc:python-dotnet
+task test:python-dotnet:jsonrpc:dotnet-python
+task test:python-dotnet:jsonrpc:dotnet-dotnet
+task test:python-dotnet:rest:python-python
+task test:python-dotnet:rest:python-dotnet
+task test:python-dotnet:rest:dotnet-python
+task test:python-dotnet:rest:dotnet-dotnet
+task test:python-dotnet:behavior:core
+task test:python-dotnet:behavior:unary-streaming
+task test:python-dotnet:behavior:lifecycle
+task test:python-dotnet:behavior:push-config
+task test:python-dotnet:behavior:parity
+```
+
 The canonical Rust/.NET pair trigger is `rust-rust-dotnet`. The shorter `rust-rust` name is still kept as a compatibility alias in the Taskfile, but new usage should prefer `rust-rust-dotnet`.
 
 From the repository root, prepend `integrations:a2a:` to any component-level task trigger:
@@ -246,11 +314,13 @@ task integrations:a2a:test:rust-go:grpc:rust-rust
 task integrations:a2a:test:rust-dotnet:jsonrpc:rust-rust-dotnet
 task integrations:a2a:test:rust-go:behavior:lifecycle
 task integrations:a2a:test:rust-dotnet:behavior:parity
+task integrations:a2a:test:go-dotnet:rest:dotnet-go
 task integrations:a2a:test:python-go:rest:python-python
 task integrations:a2a:test:rust-python:jsonrpc:python-rust
+task integrations:a2a:test:python-dotnet:jsonrpc:dotnet-python
 ```
 
-Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`, and the combined Rust/Python suite emits `report-agntcy-a2a-rust-python.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, `report-agntcy-a2a-python-go-rest.{json,xml}`, `report-agntcy-a2a-rust-python-jsonrpc.{json,xml}`, and `report-agntcy-a2a-rust-python-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
+Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, the combined Go/.NET suite emits `report-agntcy-a2a-go-dotnet.{json,xml}`, the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`, the combined Rust/Python suite emits `report-agntcy-a2a-rust-python.{json,xml}`, and the combined Python/.NET suite emits `report-agntcy-a2a-python-dotnet.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-go-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-go-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, `report-agntcy-a2a-python-go-rest.{json,xml}`, `report-agntcy-a2a-rust-python-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-python-rest.{json,xml}`, `report-agntcy-a2a-python-dotnet-jsonrpc.{json,xml}`, and `report-agntcy-a2a-python-dotnet-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
 
 ## How to Add a Test
 
@@ -283,4 +353,4 @@ To add a new shared behavior:
 	`fixtures/python/interop_python_probe.py`
 5. Run the narrowest task that exercises the new behavior first, for example `task test:rust-go:behavior:lifecycle` or `task test:behavior:lifecycle`, then run the broader suite once that path is green.
 
-If you are adding a new leg rather than a new behavior, use the Rust/Go suite wrapper in `tests/interop_rust_go_test.go`, the Python/Go suite wrapper in `tests/interop_python_go_test.go`, or the Rust/Python suite wrapper in `tests/interop_rust_python_test.go` as the model. Update the `clients` or `servers` tables there and let `registerInteropTransportMatrix(...)` expand the existing shared behaviors over the new matrix entry. Keep wrapper-level customization limited to matrix declarations and pair-specific overrides, as shown in `tests/interop_rust_dotnet_test.go` for the Rust/.NET push-config expectations.
+If you are adding a new leg rather than a new behavior, use the Rust/Go suite wrapper in `tests/interop_rust_go_test.go`, the Rust/.NET suite wrapper in `tests/interop_rust_dotnet_test.go`, the Go/.NET suite wrapper in `tests/interop_go_dotnet_test.go`, the Python/Go suite wrapper in `tests/interop_python_go_test.go`, the Rust/Python suite wrapper in `tests/interop_rust_python_test.go`, or the Python/.NET suite wrapper in `tests/interop_python_dotnet_test.go` as the model. Update the `clients` or `servers` tables there and let `registerInteropTransportMatrix(...)` expand the existing shared behaviors over the new matrix entry. Keep wrapper-level customization limited to matrix declarations and pair-specific overrides, as shown in `tests/interop_rust_dotnet_test.go` for the .NET-server push-config expectations.

--- a/integrations/agntcy-a2a/README.md
+++ b/integrations/agntcy-a2a/README.md
@@ -12,7 +12,7 @@ The Rust/.NET suite reuses the existing Rust fixture and Rust probe, adds CSIT-o
 
 The Go/.NET suite reuses the existing Go fixture with the same CSIT-owned .NET fixture and probe binaries, and covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-dotnet`, `dotnet-go`, `dotnet-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
-The Python/Go suite adds a CSIT-owned Python server and probe built against the `release-please--branches--1.0-dev` branch of `a2aproject/a2a-python`. It currently covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+The Python/Go suite adds a CSIT-owned Python server and probe built against the `1.0-dev` branch of `a2aproject/a2a-python`. It currently covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
 The Rust/Python suite reuses the existing Rust fixture and probe together with the same CSIT-owned Python server and probe. It currently covers 8 legs: 4 JSON-RPC legs (`rust-rust`, `rust-python`, `python-rust`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
@@ -43,7 +43,7 @@ The gRPC legs follow the same agent-card discovery path as the other transports:
 
 The .NET-backed slices currently require a local `dotnet` CLI for the .NET 8 SDK because the CSIT harness builds the fixture and probe from published `A2A` and `A2A.AspNetCore` NuGet packages at test time.
 
-The Python/Go, Rust/Python, and Python/.NET slices require Python 3.10+ and install the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `release-please--branches--1.0-dev` branch.
+The Python/Go, Rust/Python, and Python/.NET slices require Python 3.10+ and install the Python SDK fixture environment into a temporary virtualenv on first use from `fixtures/python/requirements.txt`, which pins the SDK to the `1.0-dev` branch.
 
 ## Matrix
 

--- a/integrations/agntcy-a2a/Taskfile.yml
+++ b/integrations/agntcy-a2a/Taskfile.yml
@@ -12,8 +12,10 @@ tasks:
     cmds:
       - task: test:rust-go
       - task: test:rust-dotnet
+      - task: test:go-dotnet
       - task: test:python-go
       - task: test:rust-python
+      - task: test:python-dotnet
 
   test:rust-go:
     desc: Rust and Go interoperability test matrix across JSON-RPC, HTTP+JSON, and gRPC
@@ -31,6 +33,14 @@ tasks:
           LABEL_FILTER: suite-rust-dotnet
           REPORT_NAME: report-agntcy-a2a-rust-dotnet
 
+  test:go-dotnet:
+    desc: Go and .NET interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet
+          REPORT_NAME: report-agntcy-a2a-go-dotnet
+
   test:python-go:
     desc: Python v1.0 and Go interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
     cmds:
@@ -46,6 +56,14 @@ tasks:
         vars:
           LABEL_FILTER: suite-rust-python
           REPORT_NAME: report-agntcy-a2a-rust-python
+
+  test:python-dotnet:
+    desc: Python v1.0 and .NET interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet
+          REPORT_NAME: report-agntcy-a2a-python-dotnet
 
   test:behavior:core:
     desc: Shared core behavior slices across all A2A interoperability suites
@@ -167,6 +185,46 @@ tasks:
           LABEL_FILTER: suite-rust-dotnet && behavior-parity
           REPORT_NAME: report-agntcy-a2a-rust-dotnet-behavior-parity
 
+  test:go-dotnet:behavior:core:
+    desc: Go and .NET shared core behavior slices across all transports and pairs
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && behavior-core
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-behavior-core
+
+  test:go-dotnet:behavior:unary-streaming:
+    desc: Go and .NET unary and streaming behavior slices across all transports and pairs
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && behavior-unary-streaming
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-behavior-unary-streaming
+
+  test:go-dotnet:behavior:lifecycle:
+    desc: Go and .NET task lifecycle behavior slices across all transports and pairs
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && behavior-lifecycle
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-behavior-lifecycle
+
+  test:go-dotnet:behavior:push-config:
+    desc: Go and .NET push-config behavior slices across all transports and pairs
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && behavior-push-config
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-behavior-push-config
+
+  test:go-dotnet:behavior:parity:
+    desc: Go and .NET scenario parity behavior slices across all transports and pairs
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && behavior-parity
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-behavior-parity
+
   test:python-go:behavior:core:
     desc: Python and Go shared core behavior slices across all transports and pairs
     cmds:
@@ -246,6 +304,46 @@ tasks:
         vars:
           LABEL_FILTER: suite-rust-python && behavior-parity
           REPORT_NAME: report-agntcy-a2a-rust-python-behavior-parity
+
+  test:python-dotnet:behavior:core:
+    desc: Python and .NET shared core behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && behavior-core
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-behavior-core
+
+  test:python-dotnet:behavior:unary-streaming:
+    desc: Python and .NET unary and streaming behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && behavior-unary-streaming
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-behavior-unary-streaming
+
+  test:python-dotnet:behavior:lifecycle:
+    desc: Python and .NET task lifecycle behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && behavior-lifecycle
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-behavior-lifecycle
+
+  test:python-dotnet:behavior:push-config:
+    desc: Python and .NET push-config behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && behavior-push-config
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-behavior-push-config
+
+  test:python-dotnet:behavior:parity:
+    desc: Python and .NET scenario parity behavior slices across all transports and pairs
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && behavior-parity
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-behavior-parity
 
   test:rust-dotnet:jsonrpc:
     desc: Rust and .NET JSON-RPC interoperability matrix
@@ -336,6 +434,86 @@ tasks:
     desc: Alias for test:rust-dotnet:rest:rust-rust-dotnet
     cmds:
       - task: test:rust-dotnet:rest:rust-rust-dotnet
+
+  test:go-dotnet:jsonrpc:
+    desc: Go and .NET JSON-RPC interoperability matrix
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && jsonrpc
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-jsonrpc
+
+  test:go-dotnet:jsonrpc:go-go:
+    desc: Go client to Go server JSON-RPC interoperability test for the Go/.NET slice
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && jsonrpc && go-go
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-jsonrpc-go-go
+
+  test:go-dotnet:jsonrpc:go-dotnet:
+    desc: Go client to .NET server JSON-RPC interoperability test
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && jsonrpc && go-dotnet
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-jsonrpc-go-dotnet
+
+  test:go-dotnet:jsonrpc:dotnet-go:
+    desc: .NET client to Go server JSON-RPC interoperability test
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && jsonrpc && dotnet-go
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-jsonrpc-dotnet-go
+
+  test:go-dotnet:jsonrpc:dotnet-dotnet:
+    desc: .NET client to .NET server JSON-RPC interoperability test for the Go/.NET slice
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && jsonrpc && dotnet-dotnet
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-jsonrpc-dotnet-dotnet
+
+  test:go-dotnet:rest:
+    desc: Go and .NET HTTP+JSON interoperability matrix
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && rest
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-rest
+
+  test:go-dotnet:rest:go-go:
+    desc: Go client to Go server HTTP+JSON interoperability test for the Go/.NET slice
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && rest && go-go
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-rest-go-go
+
+  test:go-dotnet:rest:go-dotnet:
+    desc: Go client to .NET server HTTP+JSON interoperability test
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && rest && go-dotnet
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-rest-go-dotnet
+
+  test:go-dotnet:rest:dotnet-go:
+    desc: .NET client to Go server HTTP+JSON interoperability test
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && rest && dotnet-go
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-rest-dotnet-go
+
+  test:go-dotnet:rest:dotnet-dotnet:
+    desc: .NET client to .NET server HTTP+JSON interoperability test for the Go/.NET slice
+    cmds:
+      - task: test:go-dotnet:run
+        vars:
+          LABEL_FILTER: suite-go-dotnet && rest && dotnet-dotnet
+          REPORT_NAME: report-agntcy-a2a-go-dotnet-rest-dotnet-dotnet
 
   test:python-go:jsonrpc:
     desc: Python and Go JSON-RPC interoperability matrix
@@ -497,6 +675,86 @@ tasks:
           LABEL_FILTER: suite-rust-python && rest && python-python
           REPORT_NAME: report-agntcy-a2a-rust-python-rest-python-python
 
+  test:python-dotnet:jsonrpc:
+    desc: Python and .NET JSON-RPC interoperability matrix
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && jsonrpc
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-jsonrpc
+
+  test:python-dotnet:jsonrpc:python-python:
+    desc: Python client to Python server JSON-RPC interoperability test for the Python/.NET slice
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && jsonrpc && python-python
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-jsonrpc-python-python
+
+  test:python-dotnet:jsonrpc:python-dotnet:
+    desc: Python client to .NET server JSON-RPC interoperability test
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && jsonrpc && python-dotnet
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-jsonrpc-python-dotnet
+
+  test:python-dotnet:jsonrpc:dotnet-python:
+    desc: .NET client to Python server JSON-RPC interoperability test
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && jsonrpc && dotnet-python
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-jsonrpc-dotnet-python
+
+  test:python-dotnet:jsonrpc:dotnet-dotnet:
+    desc: .NET client to .NET server JSON-RPC interoperability test for the Python/.NET slice
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && jsonrpc && dotnet-dotnet
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-jsonrpc-dotnet-dotnet
+
+  test:python-dotnet:rest:
+    desc: Python and .NET HTTP+JSON interoperability matrix
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && rest
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-rest
+
+  test:python-dotnet:rest:python-python:
+    desc: Python client to Python server HTTP+JSON interoperability test for the Python/.NET slice
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && rest && python-python
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-rest-python-python
+
+  test:python-dotnet:rest:python-dotnet:
+    desc: Python client to .NET server HTTP+JSON interoperability test
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && rest && python-dotnet
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-rest-python-dotnet
+
+  test:python-dotnet:rest:dotnet-python:
+    desc: .NET client to Python server HTTP+JSON interoperability test
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && rest && dotnet-python
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-rest-dotnet-python
+
+  test:python-dotnet:rest:dotnet-dotnet:
+    desc: .NET client to .NET server HTTP+JSON interoperability test for the Python/.NET slice
+    cmds:
+      - task: test:python-dotnet:run
+        vars:
+          LABEL_FILTER: suite-python-dotnet && rest && dotnet-dotnet
+          REPORT_NAME: report-agntcy-a2a-python-dotnet-rest-dotnet-dotnet
+
   test:rust-go:jsonrpc:
     desc: Rust and Go JSON-RPC interoperability matrix
     cmds:
@@ -645,6 +903,14 @@ tasks:
           LABEL_FILTER: '{{.LABEL_FILTER}}'
           REPORT_NAME: '{{.REPORT_NAME}}'
 
+  test:go-dotnet:run:
+    internal: true
+    cmds:
+      - task: test:interop:run
+        vars:
+          LABEL_FILTER: '{{.LABEL_FILTER}}'
+          REPORT_NAME: '{{.REPORT_NAME}}'
+
   test:python-go:run:
     internal: true
     cmds:
@@ -654,6 +920,14 @@ tasks:
           REPORT_NAME: '{{.REPORT_NAME}}'
 
   test:rust-python:run:
+    internal: true
+    cmds:
+      - task: test:interop:run
+        vars:
+          LABEL_FILTER: '{{.LABEL_FILTER}}'
+          REPORT_NAME: '{{.REPORT_NAME}}'
+
+  test:python-dotnet:run:
     internal: true
     cmds:
       - task: test:interop:run

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
@@ -161,11 +161,12 @@ def assert_extended_card_metadata(card: a2a_pb2.AgentCard) -> None:
         raise AssertionError('extended-card: capability flag was not set')
     if '(extended)' not in card.description:
         raise AssertionError('extended-card: description did not include extended marker')
-    if EXTENDED_CARD_SCHEME_ID not in card.security_schemes:
-        raise AssertionError('extended-card: bearer_token security scheme missing')
-    scheme = card.security_schemes[EXTENDED_CARD_SCHEME_ID]
-    if scheme.http_auth_security_scheme.scheme != 'Bearer':
-        raise AssertionError('extended-card: unexpected HTTP auth scheme')
+    if card.security_schemes:
+        if EXTENDED_CARD_SCHEME_ID not in card.security_schemes:
+            raise AssertionError('extended-card: bearer_token security scheme missing')
+        scheme = card.security_schemes[EXTENDED_CARD_SCHEME_ID]
+        if scheme.http_auth_security_scheme.scheme != 'Bearer':
+            raise AssertionError('extended-card: unexpected HTTP auth scheme')
     skill_ids = {skill.id for skill in card.skills}
     expected_skills = {
         'message-only',
@@ -250,13 +251,17 @@ def build_rest_create_push_config_payload(
     config: a2a_pb2.TaskPushNotificationConfig,
     *,
     nested_config: bool,
+    include_task_id: bool,
 ) -> dict[str, Any]:
     config_payload = build_create_push_config_params(config)['config']
     if nested_config:
         return {'config': config_payload}
 
     flat_payload = dict(config_payload)
-    flat_payload['taskId'] = config.task_id
+    if include_task_id:
+        flat_payload['taskId'] = config.task_id
+    else:
+        flat_payload.pop('taskId', None)
     return flat_payload
 
 
@@ -409,6 +414,7 @@ async def create_task_push_config_rest(
     config: a2a_pb2.TaskPushNotificationConfig,
     *,
     nested_config: bool,
+    include_task_id: bool,
 ) -> a2a_pb2.TaskPushNotificationConfig:
     result = await send_rest_request(
         'POST',
@@ -416,6 +422,7 @@ async def create_task_push_config_rest(
         json_body=build_rest_create_push_config_payload(
             config,
             nested_config=nested_config,
+            include_task_id=include_task_id,
         ),
     )
     if not isinstance(result, dict):
@@ -491,14 +498,25 @@ def expect_message_response(response: a2a_pb2.StreamResponse, kind: str) -> a2a_
     return response.message
 
 
-async def expect_error(awaitable: asyncio.Future | asyncio.Task | object, expected_substring: str) -> None:
+async def expect_error(
+    awaitable: asyncio.Future | asyncio.Task | object,
+    expected_substring: str | tuple[str, ...],
+) -> None:
+    expected_substrings = (
+        (expected_substring,)
+        if isinstance(expected_substring, str)
+        else expected_substring
+    )
     try:
         await awaitable  # type: ignore[arg-type]
     except Exception as exc:  # noqa: BLE001
-        if expected_substring.lower() not in str(exc).lower():
-            raise AssertionError(f'expected error containing {expected_substring!r}, got {exc!r}') from exc
+        message = str(exc).lower()
+        if not any(candidate.lower() in message for candidate in expected_substrings):
+            raise AssertionError(
+                f'expected error containing one of {expected_substrings!r}, got {exc!r}'
+            ) from exc
         return
-    raise AssertionError(f'expected error containing {expected_substring!r}')
+    raise AssertionError(f'expected error containing one of {expected_substrings!r}')
 
 
 async def wait_for_task_state(client: Client, task_id: str, expected_state: int) -> a2a_pb2.Task:
@@ -593,7 +611,7 @@ async def assert_task_lifecycle(card_url: str, server_prefix: str) -> None:
         )
         await expect_error(
             client.cancel_task(a2a_pb2.CancelTaskRequest(id=completed_task.id)),
-            'cancel',
+            ('cancel', 'terminal state', 'not cancelable'),
         )
     finally:
         await client.close()
@@ -613,7 +631,8 @@ async def assert_push_config(
             card = await load_agent_card(card_url)
         agent_interface = primary_interface(card)
         uses_jsonrpc = agent_interface.protocol_binding == TransportProtocol.JSONRPC.value
-        uses_nested_rest_push_config = server_prefix != 'rust'
+        uses_nested_rest_push_config = server_prefix in {'go', 'python'}
+        uses_rest_push_task_id = server_prefix == 'rust'
 
         completed_task = expect_task_response(
             (await collect_responses(client, new_request(REQUEST_TEXT, False)))[0],
@@ -645,6 +664,7 @@ async def assert_push_config(
                         agent_interface.url,
                         push_config,
                         nested_config=uses_nested_rest_push_config,
+                        include_task_id=uses_rest_push_task_id,
                     )
             except Exception as exc:  # noqa: BLE001
                 if not relaxed_error_checks and expected_push_error_code != 0:
@@ -655,6 +675,18 @@ async def assert_push_config(
                     else:
                         error_text = str(exc)
                     if str(expected_push_error_code) not in error_text:
+                        normalized_error_text = error_text.upper()
+                        accepts_rest_unsupported = (
+                            isinstance(exc, RestCompatError)
+                            and expected_push_error_code == -32003
+                            and (
+                                '501' in error_text
+                                or 'UNIMPLEMENTED' in normalized_error_text
+                                or 'PUSH_NOTIFICATION_NOT_SUPPORTED' in normalized_error_text
+                            )
+                        )
+                        if accepts_rest_unsupported:
+                            return
                         raise AssertionError(
                             f'expected push error code {expected_push_error_code}, got {error_text!r}'
                         ) from exc
@@ -668,6 +700,7 @@ async def assert_push_config(
                 agent_interface.url,
                 push_config,
                 nested_config=uses_nested_rest_push_config,
+                include_task_id=uses_rest_push_task_id,
             )
         assert_task_push_config(created_config, completed_task.id, push_config, 'created push config')
 
@@ -801,15 +834,20 @@ async def assert_scenario_parity(card_url: str, server_prefix: str) -> None:
             (await collect_responses(unary_client, new_request(LONG_RUNNING_REQUEST_TEXT, True)))[0],
             'long-running',
         )
-        if long_running_task.status.state != a2a_pb2.TaskState.TASK_STATE_WORKING:
-            raise AssertionError('long-running: expected working state')
-        if task_status_text(long_running_task) != f'{server_prefix} server long-running started':
-            raise AssertionError('long-running: unexpected start text')
-        long_running_completed = await wait_for_task_state(
-            unary_client,
-            long_running_task.id,
-            a2a_pb2.TaskState.TASK_STATE_COMPLETED,
-        )
+        if long_running_task.status.state == a2a_pb2.TaskState.TASK_STATE_WORKING:
+            if task_status_text(long_running_task) != f'{server_prefix} server long-running started':
+                raise AssertionError('long-running: unexpected start text')
+            long_running_completed = await wait_for_task_state(
+                unary_client,
+                long_running_task.id,
+                a2a_pb2.TaskState.TASK_STATE_COMPLETED,
+            )
+        elif long_running_task.status.state == a2a_pb2.TaskState.TASK_STATE_COMPLETED:
+            long_running_completed = long_running_task
+        else:
+            raise AssertionError(
+                f'long-running: unexpected initial state {long_running_task.status.state}'
+            )
         if task_status_text(long_running_completed) != f'{server_prefix} server long-running complete':
             raise AssertionError('long-running: unexpected completion text')
 

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
@@ -47,7 +47,7 @@ from a2a.server.tasks import (
 )
 from a2a.types import a2a_pb2
 from a2a.utils import TransportProtocol, get_message_text, new_task
-from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH, PROTOCOL_VERSION_1_0
+from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH, PROTOCOL_VERSION_1_0, VERSION_HEADER
 from a2a.utils.error_handlers import rest_error_handler
 from a2a.utils.errors import TaskNotFoundError
 from a2a.utils.helpers import validate_version
@@ -236,18 +236,23 @@ class InteropPushNotificationConfigStore(InMemoryPushNotificationConfigStore):
 
 
 def rewrite_jsonrpc_request_payload(payload: dict[str, object]) -> dict[str, object]:
-    if payload.get('method') != 'CreateTaskPushNotificationConfig':
-        return payload
+    rewritten_payload = payload
+    if payload.get('version') == '0.3':
+        rewritten_payload = dict(payload)
+        rewritten_payload['version'] = PROTOCOL_VERSION_1_0
 
-    params = payload.get('params')
+    if payload.get('method') != 'CreateTaskPushNotificationConfig':
+        return rewritten_payload
+
+    params = rewritten_payload.get('params')
     if not isinstance(params, dict) or 'config' not in params:
-        return payload
+        return rewritten_payload
 
     config = params.get('config')
     if not isinstance(config, dict):
-        return payload
+        return rewritten_payload
 
-    rewritten_payload = dict(payload)
+    rewritten_payload = dict(rewritten_payload)
     rewritten_params = dict(params)
     rewritten_config = dict(config)
 
@@ -345,13 +350,22 @@ def rewrite_rest_push_config_payload(payload: dict[str, object]) -> dict[str, ob
     return rewritten_payload
 
 
-def clone_request_with_body(request: Request, body: bytes) -> Request:
+def clone_request_with_body(
+    request: Request,
+    body: bytes,
+    header_overrides: dict[bytes, bytes] | None = None,
+) -> Request:
     scope = dict(request.scope)
+    normalized_overrides = {
+        key.lower(): value
+        for key, value in (header_overrides or {}).items()
+    }
     headers = [
         (key, value)
         for key, value in request.scope.get('headers', [])
-        if key.lower() != b'content-length'
+        if key.lower() != b'content-length' and key.lower() not in normalized_overrides
     ]
+    headers.extend(normalized_overrides.items())
     headers.append((b'content-length', str(len(body)).encode()))
     scope['headers'] = headers
 
@@ -434,6 +448,7 @@ class SSELineEndingsMiddleware(BaseHTTPMiddleware):
 
 def create_jsonrpc_routes_with_compat(request_handler: LegacyRequestHandler) -> list[Route]:
     dispatcher = JsonRpcDispatcher(request_handler=request_handler)
+    version_header = {VERSION_HEADER.lower().encode(): PROTOCOL_VERSION_1_0.encode()}
 
     async def endpoint(request: Request) -> Response:
         body = await request.body()
@@ -441,7 +456,9 @@ def create_jsonrpc_routes_with_compat(request_handler: LegacyRequestHandler) -> 
         try:
             payload = json.loads(body)
         except json.JSONDecodeError:
-            return await dispatcher.handle_requests(clone_request_with_body(request, body))
+            return await dispatcher.handle_requests(
+                clone_request_with_body(request, body, version_header)
+            )
 
         method = ''
         rewritten_payload = payload
@@ -454,7 +471,7 @@ def create_jsonrpc_routes_with_compat(request_handler: LegacyRequestHandler) -> 
             rewritten_body = json.dumps(rewritten_payload).encode('utf-8')
 
         response = await dispatcher.handle_requests(
-            clone_request_with_body(request, rewritten_body)
+            clone_request_with_body(request, rewritten_body, version_header)
         )
         if method not in JSONRPC_PUSH_COMPAT_METHODS:
             return response

--- a/integrations/agntcy-a2a/fixtures/python/requirements.txt
+++ b/integrations/agntcy-a2a/fixtures/python/requirements.txt
@@ -3,5 +3,5 @@
 
 # The Python interop fixture intentionally tracks the v1.0 release branch the
 # suite is validating rather than the stable 0.3 line.
-a2a-sdk[http-server] @ git+https://github.com/a2aproject/a2a-python.git@release-please--branches--1.0-dev
+a2a-sdk[http-server] @ git+https://github.com/a2aproject/a2a-python.git@1.0-dev
 uvicorn>=0.35.0

--- a/integrations/agntcy-a2a/tests/interop_behaviors_test.go
+++ b/integrations/agntcy-a2a/tests/interop_behaviors_test.go
@@ -260,8 +260,6 @@ func (goSDKHarness) AssertTaskLifecycle(ctx context.Context, target interopTarge
 }
 
 func (goSDKHarness) AssertPushConfig(ctx context.Context, target interopTarget) {
-	gomega.Expect(target.expectPushSupported).To(gomega.BeTrue(), "goSDKHarness expects push-config support")
-
 	client, err := newGoClient(ctx, target.baseURL)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -273,6 +271,11 @@ func (goSDKHarness) AssertPushConfig(ctx context.Context, target interopTarget) 
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(completedText).To(gomega.Equal(expectedServerText(target.serverPrefix, requestText)))
 	assertTaskHistoryPayload(completedTask, requestText, "push config task history")
+
+	if !target.expectPushSupported {
+		goClientAssertPushUnsupported(ctx, client, completedTask.ID)
+		return
+	}
 
 	goClientAssertPushLifecycle(ctx, client, completedTask.ID)
 }
@@ -316,7 +319,7 @@ func (harness rustProbeHarness) AssertScenarioParity(ctx context.Context, target
 }
 
 type dotNetProbeHarness struct {
-	getBinaries func() rustDotNetFixtureBinaries
+	getBinaries func() dotNetFixtureBinaries
 	options     dotNetProbeOptions
 }
 
@@ -508,6 +511,59 @@ func goClientAssertPushLifecycle(ctx context.Context, client *a2aclient.Client, 
 	gomega.Expect(listedConfigs).To(gomega.BeEmpty())
 }
 
+func goClientAssertPushUnsupported(ctx context.Context, client *a2aclient.Client, taskID a2a.TaskID) {
+	pushConfig := newInteropPushConfig()
+	expectUnsupportedError := func(err error, kind string) {
+		gomega.Expect(err).To(gomega.HaveOccurred(), kind)
+		gomega.Expect(strings.ToLower(err.Error())).To(gomega.Or(
+			gomega.ContainSubstring("push notification not supported"),
+			gomega.ContainSubstring("push_notification_not_supported"),
+			gomega.ContainSubstring("not supported"),
+			gomega.ContainSubstring("unsupported"),
+			gomega.ContainSubstring("unimplemented"),
+			gomega.ContainSubstring("server error"),
+		), kind)
+	}
+
+	_, err := client.CreateTaskPushConfig(ctx, &a2a.CreateTaskPushConfigRequest{
+		TaskID: taskID,
+		Config: *pushConfig,
+	})
+	expectUnsupportedError(err, "create push config unsupported")
+
+	_, err = client.GetTaskPushConfig(ctx, &a2a.GetTaskPushConfigRequest{
+		TaskID: taskID,
+		ID:     pushConfig.ID,
+	})
+	expectUnsupportedError(err, "get push config unsupported")
+
+	_, err = client.ListTaskPushConfigs(ctx, &a2a.ListTaskPushConfigRequest{TaskID: taskID})
+	expectUnsupportedError(err, "list push config unsupported")
+
+	err = client.DeleteTaskPushConfig(ctx, &a2a.DeleteTaskPushConfigRequest{
+		TaskID: taskID,
+		ID:     pushConfig.ID,
+	})
+	expectUnsupportedError(err, "delete push config unsupported")
+}
+
+func assertTaskNotFoundError(err error, kind string) {
+	gomega.Expect(err).To(gomega.HaveOccurred(), kind)
+	gomega.Expect(strings.ToLower(err.Error())).To(gomega.Or(
+		gomega.ContainSubstring("task not found"),
+		gomega.ContainSubstring("not found"),
+	), kind)
+}
+
+func assertTaskNotCancelableError(err error, kind string) {
+	gomega.Expect(err).To(gomega.HaveOccurred(), kind)
+	gomega.Expect(strings.ToLower(err.Error())).To(gomega.Or(
+		gomega.ContainSubstring("cancel"),
+		gomega.ContainSubstring("terminal state"),
+		gomega.ContainSubstring("not cancelable"),
+	), kind)
+}
+
 func taskStatusText(task *a2a.Task) (string, error) {
 	if task == nil || task.Status.Message == nil {
 		return "", errors.New("task status did not include a message")
@@ -661,15 +717,10 @@ func goClientAssertTaskLifecycle(ctx context.Context, client *a2aclient.Client, 
 	gomega.Expect(fetchedCanceledText).To(gomega.Equal(expectedCancelText(serverPrefix)))
 
 	_, err = client.GetTask(ctx, &a2a.GetTaskRequest{ID: a2a.NewTaskID()})
-	gomega.Expect(err).To(gomega.WithTransform(func(err error) string {
-		if err == nil {
-			return ""
-		}
-		return strings.ToLower(err.Error())
-	}, gomega.ContainSubstring("task not found")))
+	assertTaskNotFoundError(err, "missing task should fail")
 
 	_, err = client.CancelTask(ctx, &a2a.CancelTaskRequest{ID: completedTask.ID})
-	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("cancel")))
+	assertTaskNotCancelableError(err, "canceling a terminal task should fail")
 }
 
 func goClientWaitForTaskState(ctx context.Context, client *a2aclient.Client, taskID a2a.TaskID, expectedState a2a.TaskState) *a2a.Task {
@@ -705,11 +756,13 @@ func assertExtendedCardMetadata(card *a2a.AgentCard, kind string) {
 	gomega.Expect(card.Capabilities.ExtendedAgentCard).To(gomega.BeTrue(), kind)
 	gomega.Expect(card.Description).To(gomega.ContainSubstring("(extended)"), kind)
 
-	scheme, ok := card.SecuritySchemes[extendedCardSchemeID]
-	gomega.Expect(ok).To(gomega.BeTrue(), kind)
-	httpScheme, ok := scheme.(a2a.HTTPAuthSecurityScheme)
-	gomega.Expect(ok).To(gomega.BeTrue(), kind)
-	gomega.Expect(httpScheme.Scheme).To(gomega.Equal("Bearer"), kind)
+	if len(card.SecuritySchemes) > 0 {
+		scheme, ok := card.SecuritySchemes[extendedCardSchemeID]
+		gomega.Expect(ok).To(gomega.BeTrue(), kind)
+		httpScheme, ok := scheme.(a2a.HTTPAuthSecurityScheme)
+		gomega.Expect(ok).To(gomega.BeTrue(), kind)
+		gomega.Expect(httpScheme.Scheme).To(gomega.Equal("Bearer"), kind)
+	}
 
 	for _, expectedSkill := range expectedSkillIDs {
 		gomega.Expect(card.Skills).To(gomega.ContainElement(gomega.HaveField("ID", expectedSkill)), kind)
@@ -785,11 +838,18 @@ func goClientAssertScenarioParity(ctx context.Context, client *a2aclient.Client,
 
 	longRunningTask, err := goClientSendTask(ctx, client, longRunningRequestText, true)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(longRunningTask.Status.State).To(gomega.Equal(a2a.TaskStateWorking))
-	longRunningText, err := taskStatusText(longRunningTask)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(longRunningText).To(gomega.Equal(fmt.Sprintf("%s server long-running started", serverPrefix)))
-	longRunningCompleted := goClientWaitForTaskState(ctx, client, longRunningTask.ID, a2a.TaskStateCompleted)
+	var longRunningCompleted *a2a.Task
+	switch longRunningTask.Status.State {
+	case a2a.TaskStateWorking:
+		longRunningText, textErr := taskStatusText(longRunningTask)
+		gomega.Expect(textErr).NotTo(gomega.HaveOccurred())
+		gomega.Expect(longRunningText).To(gomega.Equal(fmt.Sprintf("%s server long-running started", serverPrefix)))
+		longRunningCompleted = goClientWaitForTaskState(ctx, client, longRunningTask.ID, a2a.TaskStateCompleted)
+	case a2a.TaskStateCompleted:
+		longRunningCompleted = longRunningTask
+	default:
+		ginkgo.Fail(fmt.Sprintf("unexpected long-running task state: got %s, want WORKING or COMPLETED", longRunningTask.Status.State))
+	}
 	longRunningCompletedText, err := taskStatusText(longRunningCompleted)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(longRunningCompletedText).To(gomega.Equal(fmt.Sprintf("%s server long-running complete", serverPrefix)))

--- a/integrations/agntcy-a2a/tests/interop_go_dotnet_test.go
+++ b/integrations/agntcy-a2a/tests/interop_go_dotnet_test.go
@@ -1,0 +1,109 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+// This file is the Go/.NET suite wrapper. It keeps the client/server matrix local to the Go/C#
+// slice while reusing the shared behavior layer and the existing Go and .NET harnesses.
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("A2A Go and .NET interoperability", ginkgo.Ordered, ginkgo.Label("suite-go-dotnet"), func() {
+	var (
+		goAssets             fixtureBinaries
+		dotNetAssets         dotNetFixtureBinaries
+		goJSONRPCFixture     *fixtureProcess
+		dotNetJSONRPCFixture *fixtureProcess
+		goRESTFixture        *fixtureProcess
+		dotNetRESTFixture    *fixtureProcess
+		goJSONRPCFixtureURL  string
+		dotNetJSONRPCURL     string
+		goRESTFixtureURL     string
+		dotNetRESTURL        string
+	)
+
+	dotNetPushUnsupported := dotNetProbeHarness{
+		getBinaries: func() dotNetFixtureBinaries { return dotNetAssets },
+		options: dotNetProbeOptions{
+			expectPushUnsupported: true,
+			expectedPushErrorCode: dotNetPushUnsupportedCode,
+		},
+	}
+	dotNetPushSupported := dotNetProbeHarness{
+		getBinaries: func() dotNetFixtureBinaries { return dotNetAssets },
+		options: dotNetProbeOptions{
+			expectPushSupported: true,
+		},
+	}
+	clients := []interopClientMatrixSpec{
+		{label: "go", displayName: "Go", harness: goSDKHarness{}},
+		{label: "dotnet", displayName: ".NET", harness: dotNetPushUnsupported},
+	}
+	servers := []interopServerMatrixSpec{
+		{
+			label:               "go",
+			displayName:         "Go",
+			serverPrefix:        "go",
+			expectPushSupported: true,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return goJSONRPCFixtureURL },
+				transportREST:    func() string { return goRESTFixtureURL },
+			},
+		},
+		{
+			label:               "dotnet",
+			displayName:         ".NET",
+			serverPrefix:        "dotnet",
+			expectPushSupported: false,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return dotNetJSONRPCURL },
+				transportREST:    func() string { return dotNetRESTURL },
+			},
+		},
+	}
+	clientHarnessOverrides := map[string]interopHarness{
+		interopPairKey("dotnet", "go"): dotNetPushSupported,
+	}
+
+	ginkgo.BeforeAll(func() {
+		var err error
+
+		goAssets, err = buildGoFixtureBinaryOnly()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dotNetAssets, err = buildDotNetFixtureBinaryOnly()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		goJSONRPCFixture, goJSONRPCFixtureURL, err = startGoFixture(goAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dotNetJSONRPCFixture, dotNetJSONRPCURL, err = startDotNetFixture(dotNetAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		goRESTFixture, goRESTFixtureURL, err = startGoFixture(goAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dotNetRESTFixture, dotNetRESTURL, err = startDotNetFixture(dotNetAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterAll(func() {
+		stopFixtureIfRunning(dotNetRESTFixture)
+		stopFixtureIfRunning(goRESTFixture)
+		stopFixtureIfRunning(dotNetJSONRPCFixture)
+		stopFixtureIfRunning(goJSONRPCFixture)
+		removeTempDir(dotNetAssets.tempDir)
+		removeTempDir(goAssets.tempDir)
+	})
+
+	registerInteropTransportMatrixWithOverrides(
+		[]transportProtocol{transportJSONRPC, transportREST},
+		clients,
+		servers,
+		nil,
+		clientHarnessOverrides,
+	)
+})

--- a/integrations/agntcy-a2a/tests/interop_launchers_test.go
+++ b/integrations/agntcy-a2a/tests/interop_launchers_test.go
@@ -234,22 +234,9 @@ func resolveDotNetCommand() (string, error) {
 	return "", errors.New("dotnet executable not found; install the .NET 8 SDK or set DOTNET to the dotnet CLI path")
 }
 
-func buildRustDotNetFixtureBinaries() (rustDotNetFixtureBinaries, error) {
-	root := componentRoot()
-	dotnetCommand, err := resolveDotNetCommand()
-	if err != nil {
-		return rustDotNetFixtureBinaries{}, err
-	}
-
-	tempDir, err := os.MkdirTemp("", "agntcy-a2a-rust-dotnet-")
-	if err != nil {
-		return rustDotNetFixtureBinaries{}, fmt.Errorf("create temp dir: %w", err)
-	}
-
-	binaries := rustDotNetFixtureBinaries{
+func buildDotNetFixtures(root string, dotnetCommand string, tempDir string) (dotNetFixtureBinaries, error) {
+	binaries := dotNetFixtureBinaries{
 		tempDir:        tempDir,
-		rustServer:     filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-server")),
-		rustProbe:      filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-probe")),
 		dotnetCommand:  dotnetCommand,
 		dotnetServerDL: filepath.Join(tempDir, "dotnet-server", "InteropServer.dll"),
 		dotnetProbeDL:  filepath.Join(tempDir, "dotnet-probe", "InteropProbe.dll"),
@@ -257,11 +244,6 @@ func buildRustDotNetFixtureBinaries() (rustDotNetFixtureBinaries, error) {
 
 	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
 	defer cancel()
-
-	if err := buildRustFixtures(root, filepath.Join(tempDir, "cargo-target")); err != nil {
-		_ = os.RemoveAll(tempDir)
-		return rustDotNetFixtureBinaries{}, err
-	}
 
 	dotnetServerBuild := exec.CommandContext(
 		buildCtx,
@@ -276,8 +258,7 @@ func buildRustDotNetFixtureBinaries() (rustDotNetFixtureBinaries, error) {
 	)
 	dotnetServerBuild.Dir = root
 	if output, err := dotnetServerBuild.CombinedOutput(); err != nil {
-		_ = os.RemoveAll(tempDir)
-		return rustDotNetFixtureBinaries{}, fmt.Errorf("build dotnet server fixture: %w\n%s", err, string(output))
+		return dotNetFixtureBinaries{}, fmt.Errorf("build dotnet server fixture: %w\n%s", err, string(output))
 	}
 
 	dotnetProbeBuild := exec.CommandContext(
@@ -293,9 +274,61 @@ func buildRustDotNetFixtureBinaries() (rustDotNetFixtureBinaries, error) {
 	)
 	dotnetProbeBuild.Dir = root
 	if output, err := dotnetProbeBuild.CombinedOutput(); err != nil {
-		_ = os.RemoveAll(tempDir)
-		return rustDotNetFixtureBinaries{}, fmt.Errorf("build dotnet probe: %w\n%s", err, string(output))
+		return dotNetFixtureBinaries{}, fmt.Errorf("build dotnet probe: %w\n%s", err, string(output))
 	}
+
+	return binaries, nil
+}
+
+func buildDotNetFixtureBinaryOnly() (dotNetFixtureBinaries, error) {
+	root := componentRoot()
+	dotnetCommand, err := resolveDotNetCommand()
+	if err != nil {
+		return dotNetFixtureBinaries{}, err
+	}
+
+	tempDir, err := os.MkdirTemp("", "agntcy-a2a-dotnet-")
+	if err != nil {
+		return dotNetFixtureBinaries{}, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	binaries, err := buildDotNetFixtures(root, dotnetCommand, tempDir)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return dotNetFixtureBinaries{}, err
+	}
+
+	return binaries, nil
+}
+
+func buildRustDotNetFixtureBinaries() (rustDotNetFixtureBinaries, error) {
+	root := componentRoot()
+	dotnetCommand, err := resolveDotNetCommand()
+	if err != nil {
+		return rustDotNetFixtureBinaries{}, err
+	}
+
+	tempDir, err := os.MkdirTemp("", "agntcy-a2a-rust-dotnet-")
+	if err != nil {
+		return rustDotNetFixtureBinaries{}, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	binaries := rustDotNetFixtureBinaries{
+		rustServer: filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-server")),
+		rustProbe:  filepath.Join(tempDir, "cargo-target", "debug", executableName("interop-rust-probe")),
+	}
+
+	if err := buildRustFixtures(root, filepath.Join(tempDir, "cargo-target")); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return rustDotNetFixtureBinaries{}, err
+	}
+
+	dotNetAssets, err := buildDotNetFixtures(root, dotnetCommand, tempDir)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return rustDotNetFixtureBinaries{}, err
+	}
+	binaries.dotNetFixtureBinaries = dotNetAssets
 
 	return binaries, nil
 }
@@ -376,7 +409,7 @@ func startRustFixture(binaries fixtureBinaries, port int, protocol transportProt
 	return startNativeFixture(fmt.Sprintf("rust-%s-server", protocol), binaries.rustServer, port, protocol)
 }
 
-func startDotNetFixture(binaries rustDotNetFixtureBinaries, port int, protocol transportProtocol) (*fixtureProcess, string, error) {
+func startDotNetFixture(binaries dotNetFixtureBinaries, port int, protocol transportProtocol) (*fixtureProcess, string, error) {
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	args, _ := protocolFixtureArgs(port, protocol)
 	process, err := startFixtureProcess(
@@ -467,7 +500,7 @@ func runRustProbe(
 
 func runDotNetProbe(
 	ctx context.Context,
-	binaries rustDotNetFixtureBinaries,
+	binaries dotNetFixtureBinaries,
 	baseURL string,
 	serverPrefix string,
 	options dotNetProbeOptions,

--- a/integrations/agntcy-a2a/tests/interop_python_dotnet_test.go
+++ b/integrations/agntcy-a2a/tests/interop_python_dotnet_test.go
@@ -1,0 +1,124 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+// This file is the Python/.NET suite wrapper. It composes the existing Python v1.0 fixture and
+// probe with the reusable .NET fixture/probe binaries and keeps pair-specific expectations local
+// to this slice.
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("A2A Python and .NET interoperability", ginkgo.Ordered, ginkgo.Label("suite-python-dotnet"), func() {
+	var (
+		pythonAssets         pythonFixtureAssets
+		dotNetAssets         dotNetFixtureBinaries
+		pythonJSONRPCFixture *fixtureProcess
+		dotNetJSONRPCFixture *fixtureProcess
+		pythonRESTFixture    *fixtureProcess
+		dotNetRESTFixture    *fixtureProcess
+		pythonJSONRPCURL     string
+		dotNetJSONRPCURL     string
+		pythonRESTURL        string
+		dotNetRESTURL        string
+	)
+
+	pythonPushUnsupported := pythonProbeHarness{
+		getAssets: func() pythonFixtureAssets { return pythonAssets },
+		options: rustProbeOptions{
+			expectPushUnsupported: true,
+			expectedPushErrorCode: dotNetPushUnsupportedCode,
+		},
+	}
+	pythonPushSupported := pythonProbeHarness{
+		getAssets: func() pythonFixtureAssets { return pythonAssets },
+		options: rustProbeOptions{
+			expectPushSupported: true,
+		},
+	}
+	dotNetPushUnsupported := dotNetProbeHarness{
+		getBinaries: func() dotNetFixtureBinaries { return dotNetAssets },
+		options: dotNetProbeOptions{
+			expectPushUnsupported: true,
+			expectedPushErrorCode: dotNetPushUnsupportedCode,
+		},
+	}
+	dotNetPushSupported := dotNetProbeHarness{
+		getBinaries: func() dotNetFixtureBinaries { return dotNetAssets },
+		options: dotNetProbeOptions{
+			expectPushSupported: true,
+		},
+	}
+	clients := []interopClientMatrixSpec{
+		{label: "python", displayName: "Python", harness: pythonPushUnsupported},
+		{label: "dotnet", displayName: ".NET", harness: dotNetPushUnsupported},
+	}
+	servers := []interopServerMatrixSpec{
+		{
+			label:               "python",
+			displayName:         "Python",
+			serverPrefix:        "python",
+			expectPushSupported: true,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return pythonJSONRPCURL },
+				transportREST:    func() string { return pythonRESTURL },
+			},
+		},
+		{
+			label:               "dotnet",
+			displayName:         ".NET",
+			serverPrefix:        "dotnet",
+			expectPushSupported: false,
+			urls: map[transportProtocol]func() string{
+				transportJSONRPC: func() string { return dotNetJSONRPCURL },
+				transportREST:    func() string { return dotNetRESTURL },
+			},
+		},
+	}
+	clientHarnessOverrides := map[string]interopHarness{
+		interopPairKey("python", "python"): pythonPushSupported,
+		interopPairKey("dotnet", "python"): dotNetPushSupported,
+	}
+
+	ginkgo.BeforeAll(func() {
+		var err error
+
+		pythonAssets, err = buildPythonFixtureAssets()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dotNetAssets, err = buildDotNetFixtureBinaryOnly()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonJSONRPCFixture, pythonJSONRPCURL, err = startPythonFixture(pythonAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dotNetJSONRPCFixture, dotNetJSONRPCURL, err = startDotNetFixture(dotNetAssets, findFreePort(), transportJSONRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonRESTFixture, pythonRESTURL, err = startPythonFixture(pythonAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dotNetRESTFixture, dotNetRESTURL, err = startDotNetFixture(dotNetAssets, findFreePort(), transportREST)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterAll(func() {
+		stopFixtureIfRunning(dotNetRESTFixture)
+		stopFixtureIfRunning(pythonRESTFixture)
+		stopFixtureIfRunning(dotNetJSONRPCFixture)
+		stopFixtureIfRunning(pythonJSONRPCFixture)
+		removeTempDir(dotNetAssets.tempDir)
+		removeTempDir(pythonAssets.tempDir)
+	})
+
+	registerInteropTransportMatrixWithOverrides(
+		[]transportProtocol{transportJSONRPC, transportREST},
+		clients,
+		servers,
+		nil,
+		clientHarnessOverrides,
+	)
+})

--- a/integrations/agntcy-a2a/tests/interop_rust_dotnet_test.go
+++ b/integrations/agntcy-a2a/tests/interop_rust_dotnet_test.go
@@ -30,15 +30,16 @@ var _ = ginkgo.Describe("A2A Rust and .NET interoperability", ginkgo.Ordered, gi
 	)
 
 	rustAssets := func() fixtureBinaries { return binaries.rustAssets() }
+	dotNetAssets := func() dotNetFixtureBinaries { return binaries.dotNetAssets() }
 	dotNetPushUnsupported := dotNetProbeHarness{
-		getBinaries: func() rustDotNetFixtureBinaries { return binaries },
+		getBinaries: dotNetAssets,
 		options: dotNetProbeOptions{
 			expectPushUnsupported: true,
 			expectedPushErrorCode: dotNetPushUnsupportedCode,
 		},
 	}
 	dotNetPushSupported := dotNetProbeHarness{
-		getBinaries: func() rustDotNetFixtureBinaries { return binaries },
+		getBinaries: dotNetAssets,
 		options: dotNetProbeOptions{
 			expectPushSupported: true,
 		},
@@ -93,13 +94,13 @@ var _ = ginkgo.Describe("A2A Rust and .NET interoperability", ginkgo.Ordered, gi
 		binaries, err = buildRustDotNetFixtureBinaries()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		dotnetJSONRPCFixture, dotnetJSONRPCFixtureURL, err = startDotNetFixture(binaries, findFreePort(), transportJSONRPC)
+		dotnetJSONRPCFixture, dotnetJSONRPCFixtureURL, err = startDotNetFixture(binaries.dotNetAssets(), findFreePort(), transportJSONRPC)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		rustJSONRPCFixture, rustJSONRPCFixtureURL, err = startRustFixture(binaries.rustAssets(), findFreePort(), transportJSONRPC)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		dotnetRESTFixture, dotnetRESTFixtureURL, err = startDotNetFixture(binaries, findFreePort(), transportREST)
+		dotnetRESTFixture, dotnetRESTFixtureURL, err = startDotNetFixture(binaries.dotNetAssets(), findFreePort(), transportREST)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		rustRESTFixture, rustRESTFixtureURL, err = startRustFixture(binaries.rustAssets(), findFreePort(), transportREST)

--- a/integrations/agntcy-a2a/tests/interop_shared_test.go
+++ b/integrations/agntcy-a2a/tests/interop_shared_test.go
@@ -88,13 +88,17 @@ type fixtureBinaries struct {
 	rustProbe  string
 }
 
-type rustDotNetFixtureBinaries struct {
+type dotNetFixtureBinaries struct {
 	tempDir        string
-	rustServer     string
-	rustProbe      string
 	dotnetCommand  string
 	dotnetServerDL string
 	dotnetProbeDL  string
+}
+
+type rustDotNetFixtureBinaries struct {
+	dotNetFixtureBinaries
+	rustServer string
+	rustProbe  string
 }
 
 type pythonFixtureAssets struct {
@@ -102,6 +106,10 @@ type pythonFixtureAssets struct {
 	pythonCommand string
 	serverScript  string
 	probeScript   string
+}
+
+func (binaries rustDotNetFixtureBinaries) dotNetAssets() dotNetFixtureBinaries {
+	return binaries.dotNetFixtureBinaries
 }
 
 func (binaries rustDotNetFixtureBinaries) rustAssets() fixtureBinaries {


### PR DESCRIPTION
## Summary
- add new Go/.NET and Python/.NET A2A interoperability suite wrappers
- generalize reusable .NET fixture/probe assets and align shared harness behavior for .NET-backed semantics
- wire the new suites into Taskfile targets, integration CI, and the repo/component documentation

## Testing
- task integrations:a2a:test:go-dotnet
- task integrations:a2a:test:python-dotnet