### PR TITLE
feat(agntcy-a2a): add python gRPC interop coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   - [A2A interoperability smoke tests](#a2a-interoperability-smoke-tests)
   - [Running tests using GitHub actions](#running-tests-using-github-actions)
   - [How to extend tests with your own test](#how-to-extend-tests-with-your-own-test)
-- [Updating the agntcy/dir testdata](#updating-the-agntcydir-testdata)
-- [Copyright Notice](#copyright-notice)
+  - [Updating the agntcy/dir testdata](#updating-the-agntcydir-testdata)
+  - [Copyright Notice](#copyright-notice)
 
 ## Architecture
 
@@ -186,12 +186,14 @@ The `integrations/agntcy-a2a` suite is self-contained and does not require a
 Kind cluster, Helm, or repository sibling checkouts. It builds and runs small
 Go, Rust, .NET, and Python fixtures locally across these suite slices:
 
-- Rust/Go across JSON-RPC, HTTP+JSON, and gRPC
-- Rust/.NET across JSON-RPC and HTTP+JSON
-- Go/.NET across JSON-RPC and HTTP+JSON
-- Python/Go across JSON-RPC and HTTP+JSON
-- Rust/Python across JSON-RPC and HTTP+JSON
-- Python/.NET across JSON-RPC and HTTP+JSON
+| SDK pair | JSON-RPC | HTTP+JSON | gRPC | Root task |
+| --- | --- | --- | --- | --- |
+| Rust/Go | Yes | Yes | Yes | `task integrations:a2a:test:rust-go` |
+| Rust/.NET | Yes | Yes | No | `task integrations:a2a:test:rust-dotnet` |
+| Go/.NET | Yes | Yes | No | `task integrations:a2a:test:go-dotnet` |
+| Python/Go | Yes | Yes | Yes | `task integrations:a2a:test:python-go` |
+| Rust/Python | Yes | Yes | Yes | `task integrations:a2a:test:rust-python` |
+| Python/.NET | Yes | Yes | No | `task integrations:a2a:test:python-dotnet` |
 
 To run it from the repository root you need:
 
@@ -205,6 +207,7 @@ To run it from the repository root you need:
 task integrations:a2a:test
 task integrations:a2a:test:rust-go:jsonrpc
 task integrations:a2a:test:go-dotnet
+task integrations:a2a:test:python-go:grpc
 task integrations:a2a:test:python-go
 task integrations:a2a:test:rust-python
 task integrations:a2a:test:python-dotnet

--- a/integrations/agntcy-a2a/README.md
+++ b/integrations/agntcy-a2a/README.md
@@ -4,7 +4,7 @@ This component hosts cross-SDK A2A interoperability checks.
 
 The suite is structured around shared Ginkgo behaviors and per-SDK harnesses. The behavior assertions are written once, expanded across client/server transport matrices, and the language-specific differences are isolated behind Go, Rust, .NET, and Python launchers or probes.
 
-The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC; .NET-backed suites for Rust, Go, and Python across JSON-RPC and HTTP+JSON; and Python v1.0 suites for both Go and Rust across JSON-RPC and HTTP+JSON. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
+The current coverage includes a Rust/Go suite across JSON-RPC, HTTP+JSON, and gRPC; .NET-backed suites for Rust, Go, and Python across JSON-RPC and HTTP+JSON; and Python v1.0 suites for both Go and Rust across JSON-RPC, HTTP+JSON, and gRPC. Each client/server leg is split into shared behavior slices for unary and streaming requests, task lifecycle APIs, push-config semantics, and scenario parity.
 
 All 12 Rust/Go client-server legs are green across JSON-RPC, HTTP+JSON, and gRPC. The Go and Rust fixtures expose push-config CRUD, and CSIT validates that path from both clients against both server targets across all three transports.
 
@@ -12,9 +12,9 @@ The Rust/.NET suite reuses the existing Rust fixture and Rust probe, adds CSIT-o
 
 The Go/.NET suite reuses the existing Go fixture with the same CSIT-owned .NET fixture and probe binaries, and covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-dotnet`, `dotnet-go`, `dotnet-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
-The Python/Go suite adds a CSIT-owned Python server and probe built against the `1.0-dev` branch of `a2aproject/a2a-python`. It currently covers 8 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+The Python/Go suite adds a CSIT-owned Python server and probe built against the `1.0-dev` branch of `a2aproject/a2a-python`. It now covers 12 legs: 4 JSON-RPC legs (`go-go`, `go-python`, `python-go`, `python-python`), the same 4 legs over HTTP+JSON, and the same 4 legs over gRPC.
 
-The Rust/Python suite reuses the existing Rust fixture and probe together with the same CSIT-owned Python server and probe. It currently covers 8 legs: 4 JSON-RPC legs (`rust-rust`, `rust-python`, `python-rust`, `python-python`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
+The Rust/Python suite reuses the existing Rust fixture and probe together with the same CSIT-owned Python server and probe. It now covers 12 legs: 4 JSON-RPC legs (`rust-rust`, `rust-python`, `python-rust`, `python-python`), the same 4 legs over HTTP+JSON, and the same 4 legs over gRPC.
 
 The Python/.NET suite reuses the same CSIT-owned Python server and probe together with the same .NET fixture and probe binaries. It currently covers 8 legs: 4 JSON-RPC legs (`python-python`, `python-dotnet`, `dotnet-python`, `dotnet-dotnet`) plus the same 4 legs over HTTP+JSON. This slice does not currently cover gRPC.
 
@@ -51,14 +51,14 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 
 ### SDK Pair Coverage
 
-| SDK pair | JSON-RPC | HTTP+JSON | gRPC |
-| --- | --- | --- | --- |
-| Rust/Go | ✅ | ✅ | ✅ |
-| Rust/.NET | ✅ | ✅ | ❌ |
-| Go/.NET | ✅ | ✅ | ❌ |
-| Python/Go | ✅ | ✅ | ❌ |
-| Rust/Python | ✅ | ✅ | ❌ |
-| Python/.NET | ✅ | ✅ | ❌ |
+| SDK pair | JSON-RPC | HTTP+JSON | gRPC | Component task |
+| --- | --- | --- | --- | --- |
+| Rust/Go | ✅ | ✅ | ✅ | `task test:rust-go` |
+| Rust/.NET | ✅ | ✅ | ❌ | `task test:rust-dotnet` |
+| Go/.NET | ✅ | ✅ | ❌ | `task test:go-dotnet` |
+| Python/Go | ✅ | ✅ | ✅ | `task test:python-go` |
+| Rust/Python | ✅ | ✅ | ✅ | `task test:rust-python` |
+| Python/.NET | ✅ | ✅ | ❌ | `task test:python-dotnet` |
 
 ### Rust/Go Leg Coverage
 
@@ -91,19 +91,19 @@ Legend: ✅ covered by passing automated CSIT, ❌ not currently covered by this
 
 | Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
 | --- | --- | --- | --- |
-| Go -> Go (Python/Go slice) | ✅ | ✅ | ❌ |
-| Go -> Python | ✅ | ✅ | ❌ |
-| Python -> Go | ✅ | ✅ | ❌ |
-| Python -> Python | ✅ | ✅ | ❌ |
+| Go -> Go (Python/Go slice) | ✅ | ✅ | ✅ |
+| Go -> Python | ✅ | ✅ | ✅ |
+| Python -> Go | ✅ | ✅ | ✅ |
+| Python -> Python | ✅ | ✅ | ✅ |
 
 ### Rust/Python Leg Coverage
 
 | Client -> Server | JSON-RPC | HTTP+JSON | gRPC |
 | --- | --- | --- | --- |
-| Rust -> Rust (Rust/Python slice) | ✅ | ✅ | ❌ |
-| Rust -> Python | ✅ | ✅ | ❌ |
-| Python -> Rust | ✅ | ✅ | ❌ |
-| Python -> Python (Rust/Python slice) | ✅ | ✅ | ❌ |
+| Rust -> Rust (Rust/Python slice) | ✅ | ✅ | ✅ |
+| Rust -> Python | ✅ | ✅ | ✅ |
+| Python -> Rust | ✅ | ✅ | ✅ |
+| Python -> Python (Rust/Python slice) | ✅ | ✅ | ✅ |
 
 ### Python/.NET Leg Coverage
 
@@ -249,6 +249,7 @@ task test:go-dotnet:behavior:parity
 ```sh
 task test:python-go:jsonrpc
 task test:python-go:rest
+task test:python-go:grpc
 task test:python-go:jsonrpc:go-go
 task test:python-go:jsonrpc:go-python
 task test:python-go:jsonrpc:python-go
@@ -257,6 +258,10 @@ task test:python-go:rest:go-go
 task test:python-go:rest:go-python
 task test:python-go:rest:python-go
 task test:python-go:rest:python-python
+task test:python-go:grpc:go-go
+task test:python-go:grpc:go-python
+task test:python-go:grpc:python-go
+task test:python-go:grpc:python-python
 task test:python-go:behavior:core
 task test:python-go:behavior:unary-streaming
 task test:python-go:behavior:lifecycle
@@ -269,6 +274,7 @@ task test:python-go:behavior:parity
 ```sh
 task test:rust-python:jsonrpc
 task test:rust-python:rest
+task test:rust-python:grpc
 task test:rust-python:jsonrpc:rust-rust
 task test:rust-python:jsonrpc:rust-python
 task test:rust-python:jsonrpc:python-rust
@@ -277,6 +283,10 @@ task test:rust-python:rest:rust-rust
 task test:rust-python:rest:rust-python
 task test:rust-python:rest:python-rust
 task test:rust-python:rest:python-python
+task test:rust-python:grpc:rust-rust
+task test:rust-python:grpc:rust-python
+task test:rust-python:grpc:python-rust
+task test:rust-python:grpc:python-python
 task test:rust-python:behavior:core
 task test:rust-python:behavior:unary-streaming
 task test:rust-python:behavior:lifecycle
@@ -316,11 +326,13 @@ task integrations:a2a:test:rust-go:behavior:lifecycle
 task integrations:a2a:test:rust-dotnet:behavior:parity
 task integrations:a2a:test:go-dotnet:rest:dotnet-go
 task integrations:a2a:test:python-go:rest:python-python
+task integrations:a2a:test:python-go:grpc:python-python
 task integrations:a2a:test:rust-python:jsonrpc:python-rust
+task integrations:a2a:test:rust-python:grpc:python-python
 task integrations:a2a:test:python-dotnet:jsonrpc:dotnet-python
 ```
 
-Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, the combined Go/.NET suite emits `report-agntcy-a2a-go-dotnet.{json,xml}`, the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`, the combined Rust/Python suite emits `report-agntcy-a2a-rust-python.{json,xml}`, and the combined Python/.NET suite emits `report-agntcy-a2a-python-dotnet.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-go-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-go-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, `report-agntcy-a2a-python-go-rest.{json,xml}`, `report-agntcy-a2a-rust-python-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-python-rest.{json,xml}`, `report-agntcy-a2a-python-dotnet-jsonrpc.{json,xml}`, and `report-agntcy-a2a-python-dotnet-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
+Each run writes Ginkgo JSON and JUnit reports under `integrations/agntcy-a2a/reports/`. The combined Rust/Go suite emits `report-agntcy-a2a.{json,xml}`, the combined Rust/.NET suite emits `report-agntcy-a2a-rust-dotnet.{json,xml}`, the combined Go/.NET suite emits `report-agntcy-a2a-go-dotnet.{json,xml}`, the combined Python/Go suite emits `report-agntcy-a2a-python-go.{json,xml}`, the combined Rust/Python suite emits `report-agntcy-a2a-rust-python.{json,xml}`, and the combined Python/.NET suite emits `report-agntcy-a2a-python-dotnet.{json,xml}`. The transport-scoped tasks emit `report-agntcy-a2a-jsonrpc.{json,xml}`, `report-agntcy-a2a-rest.{json,xml}`, `report-agntcy-a2a-grpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-dotnet-rest.{json,xml}`, `report-agntcy-a2a-go-dotnet-jsonrpc.{json,xml}`, `report-agntcy-a2a-go-dotnet-rest.{json,xml}`, `report-agntcy-a2a-python-go-jsonrpc.{json,xml}`, `report-agntcy-a2a-python-go-rest.{json,xml}`, `report-agntcy-a2a-python-go-grpc.{json,xml}`, `report-agntcy-a2a-rust-python-jsonrpc.{json,xml}`, `report-agntcy-a2a-rust-python-rest.{json,xml}`, `report-agntcy-a2a-rust-python-grpc.{json,xml}`, `report-agntcy-a2a-python-dotnet-jsonrpc.{json,xml}`, and `report-agntcy-a2a-python-dotnet-rest.{json,xml}`, and the per-case tasks emit scenario-specific report names via `-ginkgo.label-filter`.
 
 ## How to Add a Test
 

--- a/integrations/agntcy-a2a/Taskfile.yml
+++ b/integrations/agntcy-a2a/Taskfile.yml
@@ -42,7 +42,7 @@ tasks:
           REPORT_NAME: report-agntcy-a2a-go-dotnet
 
   test:python-go:
-    desc: Python v1.0 and Go interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
+    desc: Python v1.0 and Go interoperability test matrix across JSON-RPC, HTTP+JSON, and gRPC
     cmds:
       - task: test:python-go:run
         vars:
@@ -50,7 +50,7 @@ tasks:
           REPORT_NAME: report-agntcy-a2a-python-go
 
   test:rust-python:
-    desc: Rust and Python v1.0 interoperability test matrix for the current JSON-RPC and HTTP+JSON slices
+    desc: Rust and Python v1.0 interoperability test matrix across JSON-RPC, HTTP+JSON, and gRPC
     cmds:
       - task: test:rust-python:run
         vars:
@@ -595,6 +595,46 @@ tasks:
           LABEL_FILTER: suite-python-go && rest && python-python
           REPORT_NAME: report-agntcy-a2a-python-go-rest-python-python
 
+  test:python-go:grpc:
+    desc: Python and Go gRPC interoperability matrix
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && grpc
+          REPORT_NAME: report-agntcy-a2a-python-go-grpc
+
+  test:python-go:grpc:go-go:
+    desc: Go client to Go server gRPC interoperability test for the Python/Go slice
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && grpc && go-go
+          REPORT_NAME: report-agntcy-a2a-python-go-grpc-go-go
+
+  test:python-go:grpc:go-python:
+    desc: Go client to Python server gRPC interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && grpc && go-python
+          REPORT_NAME: report-agntcy-a2a-python-go-grpc-go-python
+
+  test:python-go:grpc:python-go:
+    desc: Python client to Go server gRPC interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && grpc && python-go
+          REPORT_NAME: report-agntcy-a2a-python-go-grpc-python-go
+
+  test:python-go:grpc:python-python:
+    desc: Python client to Python server gRPC interoperability test
+    cmds:
+      - task: test:python-go:run
+        vars:
+          LABEL_FILTER: suite-python-go && grpc && python-python
+          REPORT_NAME: report-agntcy-a2a-python-go-grpc-python-python
+
   test:rust-python:jsonrpc:
     desc: Rust and Python JSON-RPC interoperability matrix
     cmds:
@@ -674,6 +714,46 @@ tasks:
         vars:
           LABEL_FILTER: suite-rust-python && rest && python-python
           REPORT_NAME: report-agntcy-a2a-rust-python-rest-python-python
+
+  test:rust-python:grpc:
+    desc: Rust and Python gRPC interoperability matrix
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && grpc
+          REPORT_NAME: report-agntcy-a2a-rust-python-grpc
+
+  test:rust-python:grpc:rust-rust:
+    desc: Rust client to Rust server gRPC interoperability test for the Rust/Python slice
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && grpc && rust-rust
+          REPORT_NAME: report-agntcy-a2a-rust-python-grpc-rust-rust
+
+  test:rust-python:grpc:rust-python:
+    desc: Rust client to Python server gRPC interoperability test
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && grpc && rust-python
+          REPORT_NAME: report-agntcy-a2a-rust-python-grpc-rust-python
+
+  test:rust-python:grpc:python-rust:
+    desc: Python client to Rust server gRPC interoperability test
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && grpc && python-rust
+          REPORT_NAME: report-agntcy-a2a-rust-python-grpc-python-rust
+
+  test:rust-python:grpc:python-python:
+    desc: Python client to Python server gRPC interoperability test for the Rust/Python slice
+    cmds:
+      - task: test:rust-python:run
+        vars:
+          LABEL_FILTER: suite-rust-python && grpc && python-python
+          REPORT_NAME: report-agntcy-a2a-rust-python-grpc-python-python
 
   test:python-dotnet:jsonrpc:
     desc: Python and .NET JSON-RPC interoperability matrix

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_probe.py
@@ -15,8 +15,10 @@ import asyncio
 import json
 from collections.abc import AsyncIterator
 from typing import Any
+from urllib.parse import urlparse
 from uuid import uuid4
 
+import grpc
 import httpx
 
 from google.protobuf.json_format import MessageToDict, ParseDict
@@ -196,9 +198,23 @@ class RestCompatError(RuntimeError):
         self.data = data
 
 
+def resolve_card_url(base_url: str) -> str:
+    if base_url.rstrip('/').endswith('/.well-known/agent-card.json'):
+        return base_url
+    return f"{base_url.rstrip('/')}/.well-known/agent-card.json"
+
+
+def grpc_target(address: str) -> str:
+    if '://' not in address:
+        return address
+
+    parsed = urlparse(address)
+    return parsed.netloc or address
+
+
 async def load_agent_card(card_url: str) -> a2a_pb2.AgentCard:
     async with httpx.AsyncClient(timeout=5.0) as client:
-        response = await client.get(card_url)
+        response = await client.get(resolve_card_url(card_url))
         response.raise_for_status()
         payload = response.json()
     return ParseDict(payload, a2a_pb2.AgentCard())
@@ -467,13 +483,44 @@ async def delete_task_push_config_rest(
 async def create_probe_client(card_url: str, streaming: bool) -> Client:
     config = ClientConfig(
         streaming=streaming,
+        grpc_channel_factory=lambda address: grpc.aio.insecure_channel(grpc_target(address)),
         supported_protocol_bindings=[
+            TransportProtocol.GRPC,
             TransportProtocol.JSONRPC,
             TransportProtocol.HTTP_JSON,
         ],
         httpx_client=httpx.AsyncClient(timeout=5.0),
     )
     return await create_client(card_url, client_config=config)
+
+
+async def create_task_push_config_grpc(
+    client: Client,
+    config: a2a_pb2.TaskPushNotificationConfig,
+) -> a2a_pb2.TaskPushNotificationConfig:
+    return await client.create_task_push_notification_config(config)
+
+
+async def get_task_push_config_grpc(
+    client: Client,
+    request: a2a_pb2.GetTaskPushNotificationConfigRequest,
+) -> a2a_pb2.TaskPushNotificationConfig:
+    return await client.get_task_push_notification_config(request)
+
+
+async def list_task_push_configs_grpc(
+    client: Client,
+    request: a2a_pb2.ListTaskPushNotificationConfigsRequest,
+) -> list[a2a_pb2.TaskPushNotificationConfig]:
+    response = await client.list_task_push_notification_configs(request)
+    return list(response.configs)
+
+
+async def delete_task_push_config_grpc(
+    client: Client,
+    request: a2a_pb2.DeleteTaskPushNotificationConfigRequest,
+) -> None:
+    await client.delete_task_push_notification_config(request)
 
 
 async def collect_responses(
@@ -630,6 +677,7 @@ async def assert_push_config(
         if not isinstance(card, a2a_pb2.AgentCard):
             card = await load_agent_card(card_url)
         agent_interface = primary_interface(card)
+        uses_grpc = agent_interface.protocol_binding == TransportProtocol.GRPC.value
         uses_jsonrpc = agent_interface.protocol_binding == TransportProtocol.JSONRPC.value
         uses_nested_rest_push_config = server_prefix in {'go', 'python'}
         uses_rest_push_task_id = server_prefix == 'rust'
@@ -657,7 +705,9 @@ async def assert_push_config(
 
         if not expect_push_supported:
             try:
-                if uses_jsonrpc:
+                if uses_grpc:
+                    await create_task_push_config_grpc(client, push_config)
+                elif uses_jsonrpc:
                     await create_task_push_config_jsonrpc(agent_interface.url, push_config)
                 else:
                     await create_task_push_config_rest(
@@ -685,7 +735,12 @@ async def assert_push_config(
                                 or 'PUSH_NOTIFICATION_NOT_SUPPORTED' in normalized_error_text
                             )
                         )
-                        if accepts_rest_unsupported:
+                        accepts_grpc_unsupported = (
+                            uses_grpc
+                            and expected_push_error_code == -32003
+                            and 'UNIMPLEMENTED' in normalized_error_text
+                        )
+                        if accepts_rest_unsupported or accepts_grpc_unsupported:
                             return
                         raise AssertionError(
                             f'expected push error code {expected_push_error_code}, got {error_text!r}'
@@ -693,7 +748,9 @@ async def assert_push_config(
                 return
             raise AssertionError('expected push configuration to be unsupported')
 
-        if uses_jsonrpc:
+        if uses_grpc:
+            created_config = await create_task_push_config_grpc(client, push_config)
+        elif uses_jsonrpc:
             created_config = await create_task_push_config_jsonrpc(agent_interface.url, push_config)
         else:
             created_config = await create_task_push_config_rest(
@@ -708,14 +765,18 @@ async def assert_push_config(
             task_id=completed_task.id,
             id=push_config.id,
         )
-        if uses_jsonrpc:
+        if uses_grpc:
+            fetched_config = await get_task_push_config_grpc(client, get_request)
+        elif uses_jsonrpc:
             fetched_config = await get_task_push_config_jsonrpc(agent_interface.url, get_request)
         else:
             fetched_config = await get_task_push_config_rest(agent_interface.url, get_request)
         assert_task_push_config(fetched_config, completed_task.id, push_config, 'fetched push config')
 
         list_request = a2a_pb2.ListTaskPushNotificationConfigsRequest(task_id=completed_task.id)
-        if uses_jsonrpc:
+        if uses_grpc:
+            listed_configs = await list_task_push_configs_grpc(client, list_request)
+        elif uses_jsonrpc:
             listed_configs = await list_task_push_configs_jsonrpc(agent_interface.url, list_request)
         else:
             listed_configs = await list_task_push_configs_rest(agent_interface.url, list_request)
@@ -728,7 +789,10 @@ async def assert_push_config(
             task_id=completed_task.id,
             id=push_config.id,
         )
-        if uses_jsonrpc:
+        if uses_grpc:
+            await delete_task_push_config_grpc(client, delete_request)
+            listed_configs = await list_task_push_configs_grpc(client, list_request)
+        elif uses_jsonrpc:
             await delete_task_push_config_jsonrpc(agent_interface.url, delete_request)
             listed_configs = await list_task_push_configs_jsonrpc(agent_interface.url, list_request)
         else:

--- a/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
+++ b/integrations/agntcy-a2a/fixtures/python/interop_python_server.py
@@ -5,7 +5,7 @@
 
 This server mirrors the behavior contract already exercised by the shared Go
 interop suite, but implements it using the Python SDK from the
-release-please--branches--1.0-dev branch.
+1.0-dev branch.
 
 Use this file when adding or adjusting Python server-side parity behavior. Keep
 transport bootstrapping in this file and leave cross-SDK assertions in the Go
@@ -22,6 +22,8 @@ from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import grpc
+import grpc.aio
 import uvicorn
 
 from google.protobuf.json_format import MessageToDict, ParseDict
@@ -31,10 +33,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
+import a2a.types.a2a_pb2_grpc as a2a_pb2_grpc
+
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.context import ServerCallContext
 from a2a.server.events import EventQueue
-from a2a.server.request_handlers import LegacyRequestHandler
+from a2a.server.request_handlers import GrpcHandler, LegacyRequestHandler
 from a2a.server.routes import (
     create_agent_card_routes,
     create_rest_routes,
@@ -170,13 +174,27 @@ def scenario_skills() -> list[a2a_pb2.AgentSkill]:
     ]
 
 
-def build_agent_card(base_url: str, protocol: str, extended: bool) -> a2a_pb2.AgentCard:
+def build_agent_card(
+    base_url: str,
+    protocol: str,
+    extended: bool,
+    grpc_port: int | None = None,
+) -> a2a_pb2.AgentCard:
     if protocol == 'rest':
         name = 'CSIT Python REST Agent'
         interface = a2a_pb2.AgentInterface(
             protocol_binding=TransportProtocol.HTTP_JSON.value,
             protocol_version='1.0',
             url=base_url,
+        )
+    elif protocol == 'grpc':
+        if grpc_port is None:
+            raise ValueError('gRPC transport requires --grpc-port')
+        name = 'CSIT Python gRPC Agent'
+        interface = a2a_pb2.AgentInterface(
+            protocol_binding=TransportProtocol.GRPC.value,
+            protocol_version='1.0',
+            url=f'127.0.0.1:{grpc_port}',
         )
     else:
         name = 'CSIT Python JSON-RPC Agent'
@@ -798,10 +816,14 @@ class InteropExecutor(AgentExecutor):
         )
 
 
-def build_app(port: int, protocol: str) -> Starlette:
+def build_app(
+    port: int,
+    protocol: str,
+    grpc_port: int | None = None,
+) -> tuple[Starlette, LegacyRequestHandler]:
     base_url = f'http://127.0.0.1:{port}'
-    public_card = build_agent_card(base_url, protocol, extended=False)
-    extended_card = build_agent_card(base_url, protocol, extended=True)
+    public_card = build_agent_card(base_url, protocol, extended=False, grpc_port=grpc_port)
+    extended_card = build_agent_card(base_url, protocol, extended=True, grpc_port=grpc_port)
     request_handler = LegacyRequestHandler(
         agent_executor=InteropExecutor(),
         task_store=InMemoryTaskStore(),
@@ -815,25 +837,86 @@ def build_app(port: int, protocol: str) -> Starlette:
     ]
     if protocol == 'rest':
         routes.extend(create_rest_routes_with_compat(request_handler))
-    else:
+    elif protocol == 'jsonrpc':
         routes.extend(create_jsonrpc_routes_with_compat(request_handler))
 
     app = Starlette(routes=routes)
     app.add_middleware(SSELineEndingsMiddleware)
-    return app
+    return app, request_handler
+
+
+class InteropGrpcHandler(GrpcHandler):
+    async def ListTaskPushNotificationConfigs(
+        self,
+        request: a2a_pb2.ListTaskPushNotificationConfigsRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> a2a_pb2.ListTaskPushNotificationConfigsResponse:
+        if request.page_size == 0:
+            request.page_size = 1
+        return await super().ListTaskPushNotificationConfigs(request, context)
+
+    async def ListTasks(
+        self,
+        request: a2a_pb2.ListTasksRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> a2a_pb2.ListTasksResponse:
+        if request.page_size == 0:
+            request.page_size = 1
+        return await super().ListTasks(request, context)
+
+
+async def run_grpc_fixture(http_port: int, grpc_port: int) -> None:
+    app, request_handler = build_app(http_port, 'grpc', grpc_port=grpc_port)
+    grpc_server = grpc.aio.server()
+    grpc_address = f'127.0.0.1:{grpc_port}'
+
+    a2a_pb2_grpc.add_A2AServiceServicer_to_server(
+        InteropGrpcHandler(request_handler),
+        grpc_server,
+    )
+    grpc_server.add_insecure_port(grpc_address)
+    await grpc_server.start()
+
+    LOGGER.info(
+        'python grpc fixture listening on %s with card http://127.0.0.1:%d',
+        grpc_address,
+        http_port,
+    )
+
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host='127.0.0.1',
+            port=http_port,
+            access_log=False,
+            log_level='warning',
+            lifespan='off',
+        )
+    )
+    try:
+        await server.serve()
+    finally:
+        await grpc_server.stop(0)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Run the Python A2A interop fixture server.')
     parser.add_argument('--port', type=int, required=True)
-    parser.add_argument('--protocol', choices=('jsonrpc', 'rest'), required=True)
+    parser.add_argument('--protocol', choices=('jsonrpc', 'rest', 'grpc'), required=True)
+    parser.add_argument('--grpc-port', type=int)
     return parser.parse_args()
 
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
     args = parse_args()
-    app = build_app(args.port, args.protocol)
+    if args.protocol == 'grpc':
+        if args.grpc_port is None:
+            raise SystemExit('--grpc-port is required when --protocol=grpc')
+        asyncio.run(run_grpc_fixture(args.port, args.grpc_port))
+        return
+
+    app, _ = build_app(args.port, args.protocol)
     LOGGER.info('python %s fixture listening on http://127.0.0.1:%d', args.protocol, args.port)
     uvicorn.run(
         app,

--- a/integrations/agntcy-a2a/fixtures/python/requirements.txt
+++ b/integrations/agntcy-a2a/fixtures/python/requirements.txt
@@ -3,5 +3,5 @@
 
 # The Python interop fixture intentionally tracks the v1.0 release branch the
 # suite is validating rather than the stable 0.3 line.
-a2a-sdk[http-server] @ git+https://github.com/a2aproject/a2a-python.git@1.0-dev
+a2a-sdk[grpc,http-server] @ git+https://github.com/a2aproject/a2a-python.git@1.0-dev
 uvicorn>=0.35.0

--- a/integrations/agntcy-a2a/tests/interop_launchers_test.go
+++ b/integrations/agntcy-a2a/tests/interop_launchers_test.go
@@ -427,24 +427,23 @@ func startDotNetFixture(binaries dotNetFixtureBinaries, port int, protocol trans
 }
 
 func startPythonFixture(assets pythonFixtureAssets, port int, protocol transportProtocol) (*fixtureProcess, string, error) {
-	if protocol == transportGRPC {
-		return nil, "", errors.New("python fixture does not support gRPC yet")
-	}
-
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	args, grpcAddress := protocolFixtureArgs(port, protocol)
 	process, err := startFixtureProcess(
 		fmt.Sprintf("python-%s-server", protocol),
 		componentRoot(),
 		baseURL+"/.well-known/agent-card.json",
 		assets.pythonCommand,
-		assets.serverScript,
-		"--port",
-		fmt.Sprintf("%d", port),
-		"--protocol",
-		string(protocol),
+		append([]string{assets.serverScript}, args...)...,
 	)
 	if err != nil {
 		return nil, "", err
+	}
+	if grpcAddress != "" {
+		if err := waitForTCPListener(grpcAddress, process.logs); err != nil {
+			_ = process.stop()
+			return nil, "", fmt.Errorf("wait for python-%s-server listener: %w", protocol, err)
+		}
 	}
 
 	return process, baseURL, nil

--- a/integrations/agntcy-a2a/tests/interop_python_go_test.go
+++ b/integrations/agntcy-a2a/tests/interop_python_go_test.go
@@ -22,10 +22,14 @@ var _ = ginkgo.Describe("A2A Python and Go interoperability", ginkgo.Ordered, gi
 		pythonJSONRPCFixture *fixtureProcess
 		goRESTFixture        *fixtureProcess
 		pythonRESTFixture    *fixtureProcess
+		goGRPCFixture        *fixtureProcess
+		pythonGRPCFixture    *fixtureProcess
 		goJSONRPCFixtureURL  string
 		pythonJSONRPCURL     string
 		goRESTFixtureURL     string
 		pythonRESTURL        string
+		goGRPCFixtureURL     string
+		pythonGRPCURL        string
 	)
 
 	goClient := goSDKHarness{}
@@ -48,6 +52,7 @@ var _ = ginkgo.Describe("A2A Python and Go interoperability", ginkgo.Ordered, gi
 			urls: map[transportProtocol]func() string{
 				transportJSONRPC: func() string { return goJSONRPCFixtureURL },
 				transportREST:    func() string { return goRESTFixtureURL },
+				transportGRPC:    func() string { return goGRPCFixtureURL },
 			},
 		},
 		{
@@ -58,6 +63,7 @@ var _ = ginkgo.Describe("A2A Python and Go interoperability", ginkgo.Ordered, gi
 			urls: map[transportProtocol]func() string{
 				transportJSONRPC: func() string { return pythonJSONRPCURL },
 				transportREST:    func() string { return pythonRESTURL },
+				transportGRPC:    func() string { return pythonGRPCURL },
 			},
 		},
 	}
@@ -82,9 +88,17 @@ var _ = ginkgo.Describe("A2A Python and Go interoperability", ginkgo.Ordered, gi
 
 		pythonRESTFixture, pythonRESTURL, err = startPythonFixture(pythonAssets, findFreePort(), transportREST)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		goGRPCFixture, goGRPCFixtureURL, err = startGoFixture(goAssets, findFreePort(), transportGRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonGRPCFixture, pythonGRPCURL, err = startPythonFixture(pythonAssets, findFreePort(), transportGRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterAll(func() {
+		stopFixtureIfRunning(pythonGRPCFixture)
+		stopFixtureIfRunning(goGRPCFixture)
 		stopFixtureIfRunning(pythonRESTFixture)
 		stopFixtureIfRunning(goRESTFixture)
 		stopFixtureIfRunning(pythonJSONRPCFixture)
@@ -94,7 +108,7 @@ var _ = ginkgo.Describe("A2A Python and Go interoperability", ginkgo.Ordered, gi
 	})
 
 	registerInteropTransportMatrix(
-		[]transportProtocol{transportJSONRPC, transportREST},
+		[]transportProtocol{transportJSONRPC, transportREST, transportGRPC},
 		clients,
 		servers,
 		nil,

--- a/integrations/agntcy-a2a/tests/interop_rust_python_test.go
+++ b/integrations/agntcy-a2a/tests/interop_rust_python_test.go
@@ -20,10 +20,14 @@ var _ = ginkgo.Describe("A2A Rust and Python interoperability", ginkgo.Ordered, 
 		pythonJSONRPCFixture *fixtureProcess
 		rustRESTFixture      *fixtureProcess
 		pythonRESTFixture    *fixtureProcess
+		rustGRPCFixture      *fixtureProcess
+		pythonGRPCFixture    *fixtureProcess
 		rustJSONRPCURL       string
 		pythonJSONRPCURL     string
 		rustRESTURL          string
 		pythonRESTURL        string
+		rustGRPCURL          string
+		pythonGRPCURL        string
 	)
 
 	rustClient := rustProbeHarness{
@@ -51,6 +55,7 @@ var _ = ginkgo.Describe("A2A Rust and Python interoperability", ginkgo.Ordered, 
 			urls: map[transportProtocol]func() string{
 				transportJSONRPC: func() string { return rustJSONRPCURL },
 				transportREST:    func() string { return rustRESTURL },
+				transportGRPC:    func() string { return rustGRPCURL },
 			},
 		},
 		{
@@ -61,6 +66,7 @@ var _ = ginkgo.Describe("A2A Rust and Python interoperability", ginkgo.Ordered, 
 			urls: map[transportProtocol]func() string{
 				transportJSONRPC: func() string { return pythonJSONRPCURL },
 				transportREST:    func() string { return pythonRESTURL },
+				transportGRPC:    func() string { return pythonGRPCURL },
 			},
 		},
 	}
@@ -85,9 +91,17 @@ var _ = ginkgo.Describe("A2A Rust and Python interoperability", ginkgo.Ordered, 
 
 		pythonRESTFixture, pythonRESTURL, err = startPythonFixture(pythonAssets, findFreePort(), transportREST)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		rustGRPCFixture, rustGRPCURL, err = startRustFixture(rustAssets, findFreePort(), transportGRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pythonGRPCFixture, pythonGRPCURL, err = startPythonFixture(pythonAssets, findFreePort(), transportGRPC)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterAll(func() {
+		stopFixtureIfRunning(pythonGRPCFixture)
+		stopFixtureIfRunning(rustGRPCFixture)
 		stopFixtureIfRunning(pythonRESTFixture)
 		stopFixtureIfRunning(rustRESTFixture)
 		stopFixtureIfRunning(pythonJSONRPCFixture)
@@ -97,7 +111,7 @@ var _ = ginkgo.Describe("A2A Rust and Python interoperability", ginkgo.Ordered, 
 	})
 
 	registerInteropTransportMatrix(
-		[]transportProtocol{transportJSONRPC, transportREST},
+		[]transportProtocol{transportJSONRPC, transportREST, transportGRPC},
 		clients,
 		servers,
 		nil,


### PR DESCRIPTION
## Summary
- enable Python fixture gRPC dependencies and startup in the A2A interop suite
- add Python gRPC transport handling in the probe, including push-config coverage
- extend the Python/Go and Rust/Python matrices, tasks, and docs to cover gRPC

## Validation
- task integrations:a2a:test:python-go
- task integrations:a2a:test:rust-python
- task test:python-go:grpc
- task test:rust-python:grpc