### PR TITLE
ci: publish test reports to GitHub Pages

### DIFF
--- a/.github/workflows/publish-test-reports-pages.yaml
+++ b/.github/workflows/publish-test-reports-pages.yaml
@@ -1,0 +1,209 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: publish-test-reports-pages
+
+on:
+  workflow_run:
+    workflows:
+      - test-integrations
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID to publish"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "test-report-pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      SOURCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.4'
+          cache-dependency-path: integrations/go.sum
+
+      - name: Download A2A report artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ env.SOURCE_RUN_ID }}
+          pattern: a2a-interop-test-result-*
+          merge-multiple: true
+          path: site/a2a
+
+      - name: Verify downloaded reports
+        shell: bash
+        run: |
+          set -euo pipefail
+          compgen -G "site/a2a/*.json" > /dev/null
+
+      - name: Rebuild merged A2A dashboard
+        working-directory: ./integrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          go run ./agntcy-a2a/tools/report_dashboard.go \
+            --reports-dir ../site/a2a \
+            --output ../site/a2a/index.html
+
+      - name: Build site landing page
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > site/index.html <<'EOF'
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>CSIT Test Reports</title>
+            <style>
+              :root {
+                color-scheme: light;
+                --bg: #f5f1e8;
+                --panel: rgba(255, 252, 245, 0.92);
+                --text: #1f2933;
+                --muted: #52606d;
+                --accent: #0f766e;
+                --accent-strong: #134e4a;
+                --border: rgba(15, 118, 110, 0.18);
+                --shadow: 0 24px 60px rgba(31, 41, 51, 0.12);
+              }
+              * { box-sizing: border-box; }
+              body {
+                margin: 0;
+                min-height: 100vh;
+                font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+                color: var(--text);
+                background:
+                  radial-gradient(circle at top left, rgba(15, 118, 110, 0.16), transparent 30%),
+                  radial-gradient(circle at bottom right, rgba(180, 83, 9, 0.12), transparent 28%),
+                  linear-gradient(180deg, #fbf8f3 0%, var(--bg) 100%);
+                padding: 48px 20px;
+              }
+              main {
+                max-width: 900px;
+                margin: 0 auto;
+                background: var(--panel);
+                border: 1px solid var(--border);
+                border-radius: 28px;
+                box-shadow: var(--shadow);
+                padding: 40px;
+              }
+              h1 {
+                margin: 0 0 12px;
+                font-size: clamp(2.5rem, 4vw, 4rem);
+                line-height: 0.95;
+                letter-spacing: -0.04em;
+              }
+              p {
+                margin: 0 0 16px;
+                font-size: 1.05rem;
+                line-height: 1.7;
+                color: var(--muted);
+              }
+              .card-grid {
+                display: grid;
+                gap: 18px;
+                margin-top: 32px;
+              }
+              .report-card {
+                display: block;
+                text-decoration: none;
+                color: inherit;
+                background: rgba(255, 255, 255, 0.8);
+                border: 1px solid var(--border);
+                border-radius: 20px;
+                padding: 24px;
+                transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+              }
+              .report-card:hover {
+                transform: translateY(-2px);
+                border-color: rgba(15, 118, 110, 0.34);
+                box-shadow: 0 20px 40px rgba(15, 118, 110, 0.12);
+              }
+              .eyebrow {
+                display: inline-block;
+                font-size: 0.78rem;
+                letter-spacing: 0.14em;
+                text-transform: uppercase;
+                color: var(--accent);
+                margin-bottom: 14px;
+              }
+              .report-card h2 {
+                margin: 0 0 10px;
+                font-size: 1.55rem;
+              }
+              .report-card span {
+                color: var(--accent-strong);
+                font-weight: 600;
+              }
+              footer {
+                margin-top: 32px;
+                font-size: 0.95rem;
+                color: var(--muted);
+              }
+              @media (max-width: 640px) {
+                body { padding: 20px 14px; }
+                main { padding: 28px 20px; border-radius: 22px; }
+              }
+            </style>
+          </head>
+          <body>
+            <main>
+              <div class="eyebrow">GitHub Pages</div>
+              <h1>CSIT Test Reports</h1>
+              <p>This site publishes static report outputs from CI in a format that is easy to browse and extend. The first published slice is the A2A interoperability dashboard.</p>
+              <div class="card-grid">
+                <a class="report-card" href="./a2a/">
+                  <h2>A2A interoperability</h2>
+                  <p>Cross-SDK interoperability results with merged JSON, XML, and HTML dashboard output.</p>
+                  <span>Open report</span>
+                </a>
+              </div>
+              <footer>
+                Source workflow run:
+                <a href="https://github.com/${{ github.repository }}/actions/runs/${{ env.SOURCE_RUN_ID }}">${{ env.SOURCE_RUN_ID }}</a>
+              </footer>
+            </main>
+          </body>
+          </html>
+          EOF
+          touch site/.nojekyll
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- add a dedicated workflow to publish static test reports to GitHub Pages
- trigger publication from successful test-integrations runs or from a manually supplied workflow run ID
- build a simple landing page plus a merged A2A dashboard under a standalone Pages site

## Notes
- this is intentionally split out from the active A2A refactor PR
- the site root is structured so additional report families can be added in follow-up changes
