### PR TITLE
feat(benchmarks): add SLIM basic throughput benchmark

### DIFF
--- a/.github/workflows/publish-test-reports-pages.yaml
+++ b/.github/workflows/publish-test-reports-pages.yaml
@@ -7,13 +7,22 @@ on:
   workflow_run:
     workflows:
       - test-integrations
+      - test-benchmarks-slim
     types:
       - completed
   workflow_dispatch:
     inputs:
-      run_id:
-        description: "Workflow run ID to publish"
-        required: true
+      integrations_run_id:
+        description: "Optional test-integrations run ID override"
+        required: false
+        type: string
+      benchmark_run_id:
+        description: "Optional test-benchmarks-slim run ID override"
+        required: false
+        type: string
+      slim_repo_benchmark_run_id:
+        description: "Optional agntcy/slim benchmark.yaml run ID for importing benchmark-results.csv"
+        required: false
         type: string
 
 permissions:
@@ -33,36 +42,129 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      SOURCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Resolve source runs
+        id: resolve
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          INPUT_INTEGRATIONS_RUN_ID: ${{ inputs.integrations_run_id || '' }}
+          INPUT_BENCHMARK_RUN_ID: ${{ inputs.benchmark_run_id || '' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          api_get() {
+            curl -fsSL \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "$1"
+          }
+
+          run_artifacts() {
+            local run_id="$1"
+            api_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100"
+          }
+
+          has_matching_artifact() {
+            local artifacts_json="$1"
+            local pattern="$2"
+            local count
+            count=$(echo "$artifacts_json" | jq --arg pattern "$pattern" '[.artifacts[].name | select(test($pattern))] | length')
+            [[ "$count" -gt 0 ]]
+          }
+
+          resolve_run_with_artifact() {
+            local workflow_file="$1"
+            local pattern="$2"
+            local runs_json run_ids run_id artifacts_json
+
+            runs_json=$(api_get "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs?branch=${DEFAULT_BRANCH}&status=success&per_page=15")
+            run_ids=$(echo "$runs_json" | jq -r '.workflow_runs[].id')
+
+            for run_id in $run_ids; do
+              artifacts_json=$(run_artifacts "$run_id")
+              if has_matching_artifact "$artifacts_json" "$pattern"; then
+                echo "$run_id"
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          integrations_run_id="${INPUT_INTEGRATIONS_RUN_ID}"
+          if [[ -z "$integrations_run_id" ]]; then
+            integrations_run_id="$(resolve_run_with_artifact test-integrations.yaml '^a2a-interop-test-result-' || true)"
+          fi
+
+          benchmark_run_id="${INPUT_BENCHMARK_RUN_ID}"
+          if [[ -z "$benchmark_run_id" ]]; then
+            benchmark_run_id="$(resolve_run_with_artifact test-benchmarks-slim.yaml '^slim-benchmark-smoke-report$' || true)"
+          fi
+
+          has_a2a=false
+          if [[ -n "$integrations_run_id" ]]; then
+            integrations_artifacts_json=$(run_artifacts "$integrations_run_id")
+            if has_matching_artifact "$integrations_artifacts_json" '^a2a-interop-test-result-'; then
+              has_a2a=true
+            fi
+          fi
+
+          has_benchmark_smoke=false
+          has_benchmark_capacity=false
+          has_benchmark_basic=false
+          if [[ -n "$benchmark_run_id" ]]; then
+            benchmark_artifacts_json=$(run_artifacts "$benchmark_run_id")
+            if has_matching_artifact "$benchmark_artifacts_json" '^slim-benchmark-smoke-report$'; then
+              has_benchmark_smoke=true
+            fi
+            if has_matching_artifact "$benchmark_artifacts_json" '^slim-benchmark-capacity-report$'; then
+              has_benchmark_capacity=true
+            fi
+            if has_matching_artifact "$benchmark_artifacts_json" '^slim-benchmark-basic-report$'; then
+              has_benchmark_basic=true
+            fi
+          fi
+
+          echo "integrations-run-id=$integrations_run_id" >> "$GITHUB_OUTPUT"
+          echo "benchmark-run-id=$benchmark_run_id" >> "$GITHUB_OUTPUT"
+          echo "has-a2a=$has_a2a" >> "$GITHUB_OUTPUT"
+          echo "has-benchmark-smoke=$has_benchmark_smoke" >> "$GITHUB_OUTPUT"
+          echo "has-benchmark-capacity=$has_benchmark_capacity" >> "$GITHUB_OUTPUT"
+          echo "has-benchmark-basic=$has_benchmark_basic" >> "$GITHUB_OUTPUT"
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.4'
-          cache-dependency-path: integrations/go.sum
+          cache-dependency-path: |
+            integrations/go.sum
+            benchmarks/go.sum
 
       - name: Download A2A report artifacts
+        if: ${{ steps.resolve.outputs.has-a2a == 'true' }}
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          run-id: ${{ env.SOURCE_RUN_ID }}
+          run-id: ${{ steps.resolve.outputs.integrations-run-id }}
           pattern: a2a-interop-test-result-*
           merge-multiple: true
           path: site/a2a
 
       - name: Verify downloaded reports
+        if: ${{ steps.resolve.outputs.has-a2a == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           compgen -G "site/a2a/*.json" > /dev/null
 
       - name: Rebuild merged A2A dashboard
+        if: ${{ steps.resolve.outputs.has-a2a == 'true' }}
         working-directory: ./integrations
         shell: bash
         run: |
@@ -71,10 +173,115 @@ jobs:
             --reports-dir ../site/a2a \
             --output ../site/a2a/index.html
 
+      - name: Download SLIM benchmark smoke bundle
+        if: ${{ steps.resolve.outputs.has-benchmark-smoke == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.resolve.outputs.benchmark-run-id }}
+          name: slim-benchmark-smoke-report
+          path: site/benchmarks/slim/smoke
+
+      - name: Download SLIM benchmark capacity bundle
+        if: ${{ steps.resolve.outputs.has-benchmark-capacity == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.resolve.outputs.benchmark-run-id }}
+          name: slim-benchmark-capacity-report
+          path: site/benchmarks/slim/capacity
+
+      - name: Download SLIM benchmark basic report
+        if: ${{ steps.resolve.outputs.has-benchmark-basic == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.resolve.outputs.benchmark-run-id }}
+          name: slim-benchmark-basic-report
+          path: site/benchmarks/slim/basic
+
+      - name: Download optional agntcy/slim benchmark CSV
+        id: slim-external
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.slim_repo_benchmark_run_id != '' }}
+        env:
+          SLIM_RUN_ID: ${{ inputs.slim_repo_benchmark_run_id }}
+          SLIM_TOKEN: ${{ secrets.SLIM_REPO_ACTIONS_READ_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "has-slim-external=false" >> "$GITHUB_OUTPUT"
+
+          if [[ -z "${SLIM_TOKEN}" ]]; then
+            echo "SLIM_REPO_ACTIONS_READ_TOKEN is not configured; skipping external slim benchmark import."
+            exit 0
+          fi
+
+          artifacts_json=$(curl -fsSL \
+            -H "Authorization: Bearer ${SLIM_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/agntcy/slim/actions/runs/${SLIM_RUN_ID}/artifacts?per_page=100")
+
+          download_url=$(echo "$artifacts_json" | jq -r '.artifacts[] | select(.name | startswith("benchmark-results-")) | .archive_download_url' | head -n1)
+          if [[ -z "${download_url}" ]]; then
+            echo "No retained benchmark-results artifact was found for agntcy/slim run ${SLIM_RUN_ID}."
+            exit 0
+          fi
+
+          mkdir -p site/benchmarks/slim/external
+          archive_path=$(mktemp "${RUNNER_TEMP}/slim-benchmark-XXXXXX.zip")
+          trap 'rm -f "$archive_path"' EXIT
+
+          curl -fsSL -L \
+            -H "Authorization: Bearer ${SLIM_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "$download_url" \
+            -o "$archive_path"
+
+          unzip -qo "$archive_path" -d site/benchmarks/slim/external
+          csv_path=$(find site/benchmarks/slim/external -type f -name 'benchmark-results*.csv' | head -n1 || true)
+          if [[ -z "$csv_path" ]]; then
+            echo "The downloaded artifact did not contain a benchmark-results CSV."
+            exit 0
+          fi
+
+          if [[ "$(basename "$csv_path")" != "benchmark-results.csv" ]]; then
+            cp "$csv_path" site/benchmarks/slim/external/benchmark-results.csv
+          fi
+
+          echo "has-slim-external=true" >> "$GITHUB_OUTPUT"
+
+      - name: Rebuild merged SLIM benchmark dashboard
+        if: ${{ steps.resolve.outputs.has-benchmark-smoke == 'true' || steps.resolve.outputs.has-benchmark-capacity == 'true' || steps.resolve.outputs.has-benchmark-basic == 'true' || steps.slim-external.outputs.has-slim-external == 'true' }}
+        working-directory: ./benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(go run ./agntcy-slim/tools/report_dashboard.go --smoke-dir ../site/benchmarks/slim/smoke --capacity-dir ../site/benchmarks/slim/capacity --output ../site/benchmarks/slim/index.html)
+          if [[ -f ../site/benchmarks/slim/basic/basic-benchmark-results.csv ]]; then
+            args+=(--basic-csv ../site/benchmarks/slim/basic/basic-benchmark-results.csv)
+          fi
+          if [[ -f ../site/benchmarks/slim/external/benchmark-results.csv ]]; then
+            args+=(--slim-csv ../site/benchmarks/slim/external/benchmark-results.csv)
+          fi
+          "${args[@]}"
+
       - name: Build site landing page
         shell: bash
         run: |
           set -euo pipefail
+
+          has_a2a=false
+          has_benchmarks=false
+          if [[ -f site/a2a/index.html ]]; then
+            has_a2a=true
+          fi
+          if [[ -f site/benchmarks/slim/index.html ]]; then
+            has_benchmarks=true
+          fi
+
           cat > site/index.html <<'EOF'
           <!doctype html>
           <html lang="en">
@@ -178,17 +385,57 @@ jobs:
             <main>
               <div class="eyebrow">GitHub Pages</div>
               <h1>CSIT Test Reports</h1>
-              <p>This site publishes static report outputs from CI in a format that is easy to browse and extend. The first published slice is the A2A interoperability dashboard.</p>
+              <p>This site publishes static report outputs from CI in a format that is easy to browse and extend. It currently exposes the A2A interoperability matrix and the SLIM benchmark dashboards, with optional external benchmark overlays when they are imported explicitly.</p>
               <div class="card-grid">
+          EOF
+
+          if [[ "$has_a2a" == true ]]; then
+            cat >> site/index.html <<'EOF'
                 <a class="report-card" href="./a2a/">
                   <h2>A2A interoperability</h2>
                   <p>Cross-SDK interoperability results with merged JSON, XML, and HTML dashboard output.</p>
                   <span>Open report</span>
                 </a>
+            EOF
+          fi
+
+          if [[ "$has_benchmarks" == true ]]; then
+            cat >> site/index.html <<'EOF'
+                <a class="report-card" href="./benchmarks/slim/">
+                  <h2>SLIM benchmarks</h2>
+                  <p>CSIT smoke and capacity benchmark dashboards, with support for an optional agntcy/slim data-plane benchmark CSV overlay.</p>
+                  <span>Open report</span>
+                </a>
+            EOF
+          fi
+
+          cat >> site/index.html <<'EOF'
               </div>
               <footer>
-                Source workflow run:
-                <a href="https://github.com/${{ github.repository }}/actions/runs/${{ env.SOURCE_RUN_ID }}">${{ env.SOURCE_RUN_ID }}</a>
+                Publication sources:
+          EOF
+
+          if [[ -n '${{ steps.resolve.outputs.integrations-run-id }}' ]]; then
+            cat >> site/index.html <<'EOF'
+                <a href="https://github.com/${{ github.repository }}/actions/runs/${{ steps.resolve.outputs.integrations-run-id }}">test-integrations run ${{ steps.resolve.outputs.integrations-run-id }}</a>
+            EOF
+          fi
+
+          if [[ -n '${{ steps.resolve.outputs.benchmark-run-id }}' ]]; then
+            cat >> site/index.html <<'EOF'
+                <br>
+                <a href="https://github.com/${{ github.repository }}/actions/runs/${{ steps.resolve.outputs.benchmark-run-id }}">test-benchmarks-slim run ${{ steps.resolve.outputs.benchmark-run-id }}</a>
+            EOF
+          fi
+
+          if [[ -n '${{ inputs.slim_repo_benchmark_run_id || '' }}' ]]; then
+            cat >> site/index.html <<'EOF'
+                <br>
+                <a href="https://github.com/agntcy/slim/actions/runs/${{ inputs.slim_repo_benchmark_run_id }}">agntcy/slim benchmark run ${{ inputs.slim_repo_benchmark_run_id }}</a>
+            EOF
+          fi
+
+          cat >> site/index.html <<'EOF'
               </footer>
             </main>
           </body>

--- a/.github/workflows/test-benchmarks-slim.yaml
+++ b/.github/workflows/test-benchmarks-slim.yaml
@@ -4,6 +4,14 @@
 name: test-benchmarks-slim
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-benchmarks-slim.yaml'
+      - 'Taskfile.yml'
+      - 'benchmarks/Taskfile.yml'
+      - 'benchmarks/agntcy-slim/**'
   pull_request:
     paths:
       - '.github/workflows/test-benchmarks-slim.yaml'
@@ -89,6 +97,34 @@ jobs:
             fi
           } > "$OUTPUT_FILE"
 
+      - name: Stage smoke dashboard artifact
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPORT_DIR="benchmarks/agntcy-slim/reports"
+          PUBLISH_DIR="benchmarks/agntcy-slim/published/smoke"
+
+          rm -rf "$PUBLISH_DIR"
+          mkdir -p "$PUBLISH_DIR"
+
+          for file in \
+            "$REPORT_DIR/results.tsv" \
+            "$REPORT_DIR/suite_summary.md" \
+            "$REPORT_DIR/technical_report.md" \
+            "$REPORT_DIR/ci-smoke-report.md" \
+            "$REPORT_DIR/ci-smoke.log"
+          do
+            if [ -f "$file" ]; then
+              cp "$file" "$PUBLISH_DIR/"
+            fi
+          done
+
+          task benchmarks:slim:reports:dashboard \
+            SMOKE_DIR="$PUBLISH_DIR" \
+            CAPACITY_DIR="$PUBLISH_DIR" \
+            OUTPUT_FILE="$PUBLISH_DIR/index.html"
+
       - name: Print smoke markdown report
         if: always()
         shell: bash
@@ -146,13 +182,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: slim-benchmark-smoke-report
-          path: |
-            benchmarks/agntcy-slim/reports/*.md
-            benchmarks/agntcy-slim/reports/ci-smoke.log
+          path: benchmarks/agntcy-slim/published/smoke
           retention-days: 30
 
   slim-benchmark-capacity:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.run_capacity) }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_capacity) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -229,6 +263,38 @@ jobs:
             fi
           } > "$OUTPUT_FILE"
 
+      - name: Stage capacity dashboard artifact
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPORT_DIR="benchmarks/agntcy-slim/reports"
+          PUBLISH_DIR="benchmarks/agntcy-slim/published/capacity"
+
+          rm -rf "$PUBLISH_DIR"
+          mkdir -p "$PUBLISH_DIR"
+
+          for file in \
+            "$REPORT_DIR/capacity_sweep.md" \
+            "$REPORT_DIR/capacity-fire-and-forget.md" \
+            "$REPORT_DIR/capacity-request-reply.md" \
+            "$REPORT_DIR/capacity-write.md" \
+            "$REPORT_DIR/results-fire-and-forget.tsv" \
+            "$REPORT_DIR/results-request-reply.tsv" \
+            "$REPORT_DIR/results-write.tsv" \
+            "$REPORT_DIR/ci-capacity-report.md" \
+            "$REPORT_DIR/ci-capacity.log"
+          do
+            if [ -f "$file" ]; then
+              cp "$file" "$PUBLISH_DIR/"
+            fi
+          done
+
+          task benchmarks:slim:reports:dashboard \
+            SMOKE_DIR="$PUBLISH_DIR" \
+            CAPACITY_DIR="$PUBLISH_DIR" \
+            OUTPUT_FILE="$PUBLISH_DIR/index.html"
+
       - name: Print capacity markdown report
         if: always()
         shell: bash
@@ -293,7 +359,89 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: slim-benchmark-capacity-report
-          path: |
-            benchmarks/agntcy-slim/reports/*.md
-            benchmarks/agntcy-slim/reports/ci-capacity.log
+          path: benchmarks/agntcy-slim/published/capacity
+          retention-days: 30
+
+  slim-benchmark-basic:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+        with:
+          go: true
+
+      - name: Install slimctl
+        shell: bash
+        run: |
+          task benchmarks:slim:deps:slimctl-download SLIMCTL_PATH="$HOME/.local/bin/slimctl"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install SLIM bindings
+        shell: bash
+        run: task benchmarks:slim:deps:slim-bindings-setup
+
+      - name: Run SLIM basic throughput benchmark
+        shell: bash
+        run: |
+          set -o pipefail
+          REPORT_DIR="benchmarks/agntcy-slim/reports"
+          mkdir -p "$REPORT_DIR"
+          stdbuf -oL -eL task benchmarks:slim:benchmark:ci:basic 2>&1 | tee "$REPORT_DIR/ci-basic.log"
+
+      - name: Stage basic benchmark artifact
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPORT_DIR="benchmarks/agntcy-slim/reports"
+          PUBLISH_DIR="benchmarks/agntcy-slim/published/basic"
+
+          rm -rf "$PUBLISH_DIR"
+          mkdir -p "$PUBLISH_DIR"
+
+          if [ -f "$REPORT_DIR/basic-benchmark-results.csv" ]; then
+            cp "$REPORT_DIR/basic-benchmark-results.csv" "$PUBLISH_DIR/"
+          fi
+
+          if [ -f "$REPORT_DIR/ci-basic.log" ]; then
+            cp "$REPORT_DIR/ci-basic.log" "$PUBLISH_DIR/"
+          fi
+
+      - name: Publish basic benchmark step summary
+        if: always()
+        shell: bash
+        run: |
+          REPORT_DIR="benchmarks/agntcy-slim/reports"
+
+          {
+            echo "# SLIM Basic Throughput Benchmark Summary"
+            echo
+            echo "- Workflow: ${GITHUB_WORKFLOW}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- SHA: ${GITHUB_SHA}"
+            echo
+
+            if [ -f "$REPORT_DIR/ci-basic.log" ]; then
+              echo "## Results"
+              echo
+              grep 'BASIC_BENCH_RESULT' "$REPORT_DIR/ci-basic.log" | tail -n 40 || true
+              echo
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload basic benchmark report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slim-benchmark-basic-report
+          path: benchmarks/agntcy-slim/published/basic
           retention-days: 30

--- a/benchmarks/agntcy-slim/Taskfile.yml
+++ b/benchmarks/agntcy-slim/Taskfile.yml
@@ -15,12 +15,20 @@ vars:
   BENCH_WRITE_RATES: '{{ .BENCH_WRITE_RATES | default "" }}'
   BENCH_DURATION: '{{ .BENCH_DURATION | default "5s" }}'
   BENCH_REPEATS: '{{ .BENCH_REPEATS | default "1" }}'
+  MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS | default "20" }}'
   CI_BENCH_REPEATS: '{{ .CI_BENCH_REPEATS | default "25" }}'
   SLIMCTL_RELEASE_TAG: '{{ .SLIMCTL_RELEASE_TAG | default "slimctl-v1.2.0" }}'
   SLIMCTL_PATH: '{{ .SLIMCTL_PATH | default "./bin/slimctl" }}'
   SLIM_BINDINGS_SETUP_VERSION: '{{ .SLIM_BINDINGS_SETUP_VERSION | default "v1.2.0" }}'
   CI_CAPACITY_REPEATS: '{{ .CI_CAPACITY_REPEATS | default "25" }}'
   CI_CAPACITY_SWEEP_REPEATS: '{{ .CI_CAPACITY_SWEEP_REPEATS | default "25" }}'
+
+  BASIC_BENCH_SENDERS: '{{ .BASIC_BENCH_SENDERS | default "1 2 4 8" }}'
+  BASIC_BENCH_PAYLOAD_SIZES: '{{ .BASIC_BENCH_PAYLOAD_SIZES | default "8 16 64 256 1024 4096" }}'
+  BASIC_BENCH_MSGS_PER_SENDER: '{{ .BASIC_BENCH_MSGS_PER_SENDER | default "100000" }}'
+  BASIC_BENCH_RUNS: '{{ .BASIC_BENCH_RUNS | default "3" }}'
+  CI_BASIC_BENCH_MSGS_PER_SENDER: '{{ .CI_BASIC_BENCH_MSGS_PER_SENDER | default "10000" }}'
+  BASIC_BENCH_CSV: '{{ .BASIC_BENCH_CSV | default "./reports/basic-benchmark-results.csv" }}'
 
   CAPACITY_MODES: '{{ .CAPACITY_MODES | default "fire-and-forget" }}'
   CAPACITY_CLIENTS: '{{ .CAPACITY_CLIENTS | default "1" }}'
@@ -142,6 +150,34 @@ tasks:
     cmds:
       - go test ./tests -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 30m -timeout 30m -ginkgo.v --ginkgo.json-report=../../reports/test-report-agntcy-slim.json --ginkgo.junit-report=../../reports/test-report-agntcy-slim.xml
 
+  reports:dashboard:
+    desc: Render the SLIM benchmark HTML dashboard from the available report artifacts and optional agntcy/slim CSV
+    dir: .
+    vars:
+      SMOKE_DIR: '{{ .SMOKE_DIR | default "./reports" }}'
+      CAPACITY_DIR: '{{ .CAPACITY_DIR | default "./reports" }}'
+      SLIM_REPO_CSV: '{{ .SLIM_REPO_CSV | default "./reports/external/benchmark-results.csv" }}'
+      OUTPUT_FILE: '{{ .OUTPUT_FILE | default "./reports/index.html" }}'
+    cmds:
+      - |
+        set -euo pipefail
+        cmd=(go run ./tools/report_dashboard.go --smoke-dir '{{ .SMOKE_DIR }}' --capacity-dir '{{ .CAPACITY_DIR }}' --min-ci-runs '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}' --output '{{ .OUTPUT_FILE }}')
+        if [ -n '{{ .SLIM_REPO_CSV }}' ]; then
+          cmd+=(--slim-csv '{{ .SLIM_REPO_CSV }}')
+        fi
+        if [ -f '{{ .BASIC_BENCH_CSV }}' ]; then
+          cmd+=(--basic-csv '{{ .BASIC_BENCH_CSV }}')
+        fi
+        "${cmd[@]}"
+
+  benchmark:report:
+    desc: Run the local SLIM benchmark suite and render the HTML dashboard from the generated report artifacts and optional agntcy/slim CSV
+    dir: .
+    deps:
+      - benchmark:suite
+    cmds:
+      - task reports:dashboard MIN_CONFIDENCE_INTERVAL_RUNS='{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}' SLIM_REPO_CSV='{{ .SLIM_REPO_CSV | default "./reports/external/benchmark-results.csv" }}'
+
   benchmark:suite:
     desc: Run the local SLIM benchmark suite with reproducible defaults and optional overrides
     dir: .
@@ -157,6 +193,7 @@ tasks:
       WRITE_RATES: '{{ .BENCH_WRITE_RATES }}'
       DURATION: '{{ .BENCH_DURATION }}'
       REPEATS: '{{ .BENCH_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
     cmds:
       - bash ./scripts/run_suite.sh
 
@@ -174,6 +211,7 @@ tasks:
       WRITE_RATES: '{{ .BENCH_WRITE_RATES }}'
       DURATION: '{{ .BENCH_DURATION }}'
       REPEATS: '{{ .BENCH_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
     cmds:
       - bash ./scripts/run_suite.sh
 
@@ -191,6 +229,7 @@ tasks:
       WRITE_RATES: '{{ .BENCH_WRITE_RATES }}'
       DURATION: '{{ .BENCH_DURATION }}'
       REPEATS: '{{ .BENCH_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
     cmds:
       - bash ./scripts/run_suite.sh
 
@@ -208,6 +247,7 @@ tasks:
       WRITE_RATES: '{{ .BENCH_WRITE_RATES }}'
       DURATION: '{{ .BENCH_DURATION }}'
       REPEATS: '{{ .BENCH_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
     cmds:
       - bash ./scripts/run_suite.sh
 
@@ -223,6 +263,7 @@ tasks:
       SIZES: '{{ .CAPACITY_SIZES }}'
       DURATION: '{{ .CAPACITY_DURATION }}'
       REPEATS: '{{ .CAPACITY_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
       CAPACITY_SWEEP: '1'
       CAPACITY_SWEEP_MODES: '{{ .CAPACITY_MODES }}'
       CAPACITY_SWEEP_CLIENTS: '{{ .CAPACITY_CLIENTS }}'
@@ -252,6 +293,7 @@ tasks:
       REQUEST_RATES: '{{ .REQUEST_CAPACITY_START_RATE }}'
       DURATION: '{{ .REQUEST_CAPACITY_DURATION }}'
       REPEATS: '{{ .REQUEST_CAPACITY_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
       CAPACITY_SWEEP: '1'
       CAPACITY_SWEEP_MODES: 'request-reply'
       CAPACITY_SWEEP_CLIENTS: '{{ .REQUEST_CAPACITY_CLIENTS }}'
@@ -281,6 +323,7 @@ tasks:
       PUB_RATES: '{{ .WRITE_CAPACITY_START_RATE }}'
       DURATION: '{{ .WRITE_CAPACITY_DURATION }}'
       REPEATS: '{{ .WRITE_CAPACITY_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
       CAPACITY_SWEEP: '1'
       CAPACITY_SWEEP_MODES: 'write'
       CAPACITY_SWEEP_CLIENTS: '{{ .WRITE_CAPACITY_CLIENTS }}'
@@ -297,6 +340,38 @@ tasks:
     cmds:
       - bash ./scripts/run_suite.sh
 
+  benchmark:basic:
+    desc: Run the basic throughput benchmark reproducing the upstream agntcy/slim stress_publish baseline
+    dir: .
+    deps:
+      - benchmark:local:cleanup
+      - deps:slim-bindings-setup
+    env:
+      SLIM_RUN_BASIC_BENCHMARK: '1'
+      BASIC_BENCH_SENDERS: '{{ .BASIC_BENCH_SENDERS }}'
+      BASIC_BENCH_PAYLOAD_SIZES: '{{ .BASIC_BENCH_PAYLOAD_SIZES }}'
+      BASIC_BENCH_MSGS_PER_SENDER: '{{ .BASIC_BENCH_MSGS_PER_SENDER }}'
+      BASIC_BENCH_RUNS: '{{ .BASIC_BENCH_RUNS }}'
+    cmds:
+      - go test ./tests -v -failfast -test.paniconexit0 -ginkgo.v
+          --ginkgo.label-filter basic-benchmark
+          --ginkgo.timeout 60m -timeout 60m
+
+  benchmark:ci:basic:
+    desc: Run the CI basic throughput benchmark with bandwidth-safe message counts
+    dir: .
+    deps:
+      - benchmark:local:cleanup
+      - deps:slim-bindings-setup
+    env:
+      SLIM_RUN_BASIC_BENCHMARK: '1'
+      BASIC_BENCH_MSGS_PER_SENDER: '{{ .CI_BASIC_BENCH_MSGS_PER_SENDER }}'
+      BASIC_BENCH_RUNS: '3'
+    cmds:
+      - go test ./tests -v -failfast -test.paniconexit0 -ginkgo.v
+          --ginkgo.label-filter basic-benchmark
+          --ginkgo.timeout 60m -timeout 60m
+
   benchmark:ci:suite-smoke:
     desc: Run a bounded CI-safe smoke suite across request-reply, fire-and-forget, and write with statistically meaningful repeats
     dir: .
@@ -311,6 +386,7 @@ tasks:
       PUB_RATES: '1000'
       DURATION: '1s'
       REPEATS: '{{ .CI_BENCH_REPEATS }}'
+      MIN_CONFIDENCE_INTERVAL_RUNS: '{{ .MIN_CONFIDENCE_INTERVAL_RUNS }}'
     cmds:
       - bash ./scripts/run_suite.sh
 
@@ -318,13 +394,16 @@ tasks:
     desc: Run bounded CI-safe capacity sweeps for fire-and-forget, request-reply, and write with 1 client at 16kB and statistically meaningful repeats
     dir: .
     cmds:
-      - rm -f reports/capacity-fire-and-forget.md reports/capacity-request-reply.md reports/capacity-write.md
+      - rm -f reports/capacity-fire-and-forget.md reports/capacity-request-reply.md reports/capacity-write.md reports/results-fire-and-forget.tsv reports/results-request-reply.tsv reports/results-write.tsv
       - task benchmark:capacity:fire-and-forget-16kb CAPACITY_DURATION=5s CAPACITY_REPEATS={{ .CI_CAPACITY_REPEATS }} CAPACITY_SWEEP_REPEATS={{ .CI_CAPACITY_SWEEP_REPEATS }}
       - cp reports/capacity_sweep.md reports/capacity-fire-and-forget.md
+      - cp reports/results.tsv reports/results-fire-and-forget.tsv
       - task benchmark:capacity:request-reply-16kb REQUEST_CAPACITY_DURATION=5s REQUEST_CAPACITY_REPEATS={{ .CI_CAPACITY_REPEATS }} REQUEST_CAPACITY_SWEEP_REPEATS={{ .CI_CAPACITY_SWEEP_REPEATS }}
       - cp reports/capacity_sweep.md reports/capacity-request-reply.md
+      - cp reports/results.tsv reports/results-request-reply.tsv
       - task benchmark:capacity:write-16kb WRITE_CAPACITY_DURATION=5s WRITE_CAPACITY_REPEATS={{ .CI_CAPACITY_REPEATS }} WRITE_CAPACITY_SWEEP_REPEATS={{ .CI_CAPACITY_SWEEP_REPEATS }}
       - cp reports/capacity_sweep.md reports/capacity-write.md
+      - cp reports/results.tsv reports/results-write.tsv
       - |
         set -e
         OUTPUT_FILE="reports/capacity_sweep.md"

--- a/benchmarks/agntcy-slim/tests/benchmark_basic_test.go
+++ b/benchmarks/agntcy-slim/tests/benchmark_basic_test.go
@@ -1,0 +1,230 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+// Basic throughput benchmark reproducing the upstream agntcy/slim stress_publish baseline.
+//
+// Topology: N senders (rate-client in fire-and-forget mode, -rate 0 = unlimited) publishing to
+// a single echo-client sink, routed through a local slimctl SLIM node.
+//
+// CSV output schema (matches upstream agntcy/slim benchmark-results.csv):
+//   senders, messages_per_sender, payload_bytes, total_messages,
+//   run, send_elapsed_s, total_elapsed_s, total_received, send_mps, recv_mps
+//
+// Activate with: SLIM_RUN_BASIC_BENCHMARK=1
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+type basicBenchConfig struct {
+	Senders       []int
+	PayloadSizes  []int
+	MsgsPerSender int
+	Runs          int
+	ReportDir     string
+	ResultsCSV    string
+}
+
+type basicBenchRow struct {
+	Senders       int
+	MsgsPerSender int
+	PayloadBytes  int
+	TotalMessages int64
+	Run           int
+	SendElapsedS  float64
+	TotalElapsedS float64
+	TotalReceived int64
+	SendMPS       float64
+	RecvMPS       float64
+}
+
+var _ = ginkgo.Describe("SLIM Basic Throughput Benchmark", ginkgo.Label("basic-benchmark"), func() {
+	ginkgo.It("runs the basic throughput benchmark and generates a CSV report", func() {
+		if envString("SLIM_RUN_BASIC_BENCHMARK", "") == "" {
+			ginkgo.Skip("set SLIM_RUN_BASIC_BENCHMARK=1 to run the basic throughput benchmark")
+		}
+
+		cfg := loadBasicBenchConfig()
+
+		ginkgo.By("resetting basic benchmark report artifacts")
+		gomega.Expect(os.MkdirAll(cfg.ReportDir, 0o755)).To(gomega.Succeed())
+		_ = os.Remove(cfg.ResultsCSV)
+
+		ginkgo.By("starting the local SLIM stack for the basic benchmark")
+		startLocalSlimStack()
+		defer stopLocalSlimStack()
+		stopEchoResponder()
+
+		ginkgo.By("running the basic benchmark matrix")
+		rows := runBasicBenchMatrix(cfg)
+
+		ginkgo.By("writing results CSV")
+		writeBasicBenchCSV(cfg.ResultsCSV, rows)
+
+		gomega.Expect(cfg.ResultsCSV).To(gomega.BeAnExistingFile())
+		ginkgo.AddReportEntry("Basic Benchmark Results CSV", cfg.ResultsCSV)
+	})
+})
+
+func loadBasicBenchConfig() basicBenchConfig {
+	reportDir := envString("BASIC_BENCH_REPORT_DIR", "./reports")
+	return basicBenchConfig{
+		Senders:       envIntList("BASIC_BENCH_SENDERS", []int{1, 2, 4, 8}),
+		PayloadSizes:  envIntList("BASIC_BENCH_PAYLOAD_SIZES", []int{8, 16, 64, 256, 1024, 4096}),
+		MsgsPerSender: envInt("BASIC_BENCH_MSGS_PER_SENDER", 100000),
+		Runs:          envInt("BASIC_BENCH_RUNS", 3),
+		ReportDir:     reportDir,
+		ResultsCSV:    filepath.Join(reportDir, "basic-benchmark-results.csv"),
+	}
+}
+
+func runBasicBenchMatrix(cfg basicBenchConfig) []basicBenchRow {
+	rows := make([]basicBenchRow, 0, len(cfg.Senders)*len(cfg.PayloadSizes)*cfg.Runs)
+	for _, senders := range cfg.Senders {
+		for _, payload := range cfg.PayloadSizes {
+			for run := 1; run <= cfg.Runs; run++ {
+				ginkgo.By(fmt.Sprintf("basic benchmark: senders=%d payload=%d bytes run=%d/%d",
+					senders, payload, run, cfg.Runs))
+				row := runBasicBenchCase(senders, payload, run, cfg.MsgsPerSender)
+				logBasicBenchRow(row)
+				rows = append(rows, row)
+			}
+		}
+	}
+	return rows
+}
+
+func runBasicBenchCase(senders, payloadBytes, run, msgsPerSender int) basicBenchRow {
+	totalMsgs := senders * msgsPerSender
+
+	statsFile, err := os.CreateTemp(buildDir, "basic-bench-sink-*.txt")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	statsPath := statsFile.Name()
+	gomega.Expect(statsFile.Close()).To(gomega.Succeed())
+
+	reportFile, err := os.CreateTemp(buildDir, "basic-bench-sender-*.md")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	reportPath := reportFile.Name()
+	gomega.Expect(reportFile.Close()).To(gomega.Succeed())
+
+	// Restart sink fresh for each case so elapsed_seconds is scoped to this run.
+	stopEchoResponder()
+	startEchoResponder("sink", 1, statsPath)
+
+	runStart := time.Now()
+
+	benchCmd := exec.Command(
+		rateClientPath,
+		"-mode", "fire-and-forget",
+		"-clients", strconv.Itoa(senders),
+		"-msgs", strconv.Itoa(totalMsgs),
+		"-rate", "0",
+		"-size", strconv.Itoa(payloadBytes),
+		"-local", "agntcy/demo/client",
+		"-server", serverEndpoint,
+		"-dest", "agntcy/demo/echo",
+		"-output", reportPath,
+	)
+	session, startErr := gexec.Start(benchCmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(startErr).NotTo(gomega.HaveOccurred())
+
+	// Generous timeout scaled to message count: at least 60s + 1s per 10K messages.
+	timeout := 60*time.Second + time.Duration(totalMsgs/10000)*time.Second
+	gomega.Eventually(session, timeout).Should(gexec.Exit(0),
+		"rate-client failed for senders=%d payload=%d run=%d", senders, payloadBytes, run)
+
+	// Brief drain window to let the sink receive any in-flight messages.
+	time.Sleep(500 * time.Millisecond)
+	stopEchoResponder()
+	totalElapsedS := time.Since(runStart).Seconds()
+
+	reportContent, readErr := os.ReadFile(reportPath)
+	gomega.Expect(readErr).NotTo(gomega.HaveOccurred())
+	sender := parseSenderReport(string(reportContent))
+
+	sinkContent, sinkReadErr := os.ReadFile(statsPath)
+	gomega.Expect(sinkReadErr).NotTo(gomega.HaveOccurred())
+	sink := parseSinkStats(string(sinkContent))
+
+	// Prefer the duration reported by rate-client; fall back to wall time.
+	sendElapsedS := time.Since(runStart).Seconds()
+	if d, parseErr := time.ParseDuration(sender.ActualDuration); parseErr == nil && d > 0 {
+		sendElapsedS = d.Seconds()
+	}
+
+	sendMPS := 0.0
+	if sendElapsedS > 0 && sender.TotalMessages > 0 {
+		sendMPS = float64(sender.TotalMessages) / sendElapsedS
+	}
+
+	recvMPS := 0.0
+	if totalElapsedS > 0 && sink.ReceivedMessages > 0 {
+		recvMPS = float64(sink.ReceivedMessages) / totalElapsedS
+	}
+
+	return basicBenchRow{
+		Senders:       senders,
+		MsgsPerSender: msgsPerSender,
+		PayloadBytes:  payloadBytes,
+		TotalMessages: sender.TotalMessages,
+		Run:           run,
+		SendElapsedS:  sendElapsedS,
+		TotalElapsedS: totalElapsedS,
+		TotalReceived: sink.ReceivedMessages,
+		SendMPS:       sendMPS,
+		RecvMPS:       recvMPS,
+	}
+}
+
+func logBasicBenchRow(row basicBenchRow) {
+	_ = writeProgressLine(
+		"BASIC_BENCH_RESULT senders=%d msgs_per_sender=%d payload=%d run=%d "+
+			"total_messages=%d send_elapsed_s=%.3f total_elapsed_s=%.3f "+
+			"total_received=%d send_mps=%.1f recv_mps=%.1f",
+		row.Senders, row.MsgsPerSender, row.PayloadBytes, row.Run,
+		row.TotalMessages, row.SendElapsedS, row.TotalElapsedS,
+		row.TotalReceived, row.SendMPS, row.RecvMPS,
+	)
+}
+
+func writeBasicBenchCSV(path string, rows []basicBenchRow) {
+	f, err := os.Create(path)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	gomega.Expect(w.Write([]string{
+		"senders", "messages_per_sender", "payload_bytes", "total_messages",
+		"run", "send_elapsed_s", "total_elapsed_s", "total_received", "send_mps", "recv_mps",
+	})).To(gomega.Succeed())
+
+	for _, row := range rows {
+		gomega.Expect(w.Write([]string{
+			strconv.Itoa(row.Senders),
+			strconv.Itoa(row.MsgsPerSender),
+			strconv.Itoa(row.PayloadBytes),
+			strconv.FormatInt(row.TotalMessages, 10),
+			strconv.Itoa(row.Run),
+			strconv.FormatFloat(row.SendElapsedS, 'f', 6, 64),
+			strconv.FormatFloat(row.TotalElapsedS, 'f', 6, 64),
+			strconv.FormatInt(row.TotalReceived, 10),
+			strconv.FormatFloat(row.SendMPS, 'f', 2, 64),
+			strconv.FormatFloat(row.RecvMPS, 'f', 2, 64),
+		})).To(gomega.Succeed())
+	}
+
+	w.Flush()
+	gomega.Expect(w.Error()).NotTo(gomega.HaveOccurred())
+}

--- a/benchmarks/agntcy-slim/tools/report_dashboard.go
+++ b/benchmarks/agntcy-slim/tools/report_dashboard.go
@@ -1,0 +1,1357 @@
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"html/template"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	rendererhtml "github.com/yuin/goldmark/renderer/html"
+	"gonum.org/v1/gonum/stat"
+	"gonum.org/v1/gonum/stat/distuv"
+)
+
+const (
+	confidenceIntervalAlpha              = 0.05
+	defaultMinimumConfidenceIntervalRuns = 20
+)
+
+var configuredMinimumConfidenceIntervalRuns = defaultMinimumConfidenceIntervalRuns
+
+var benchmarkModeOrder = []string{"request-reply", "fire-and-forget", "write"}
+
+type benchmarkModeSpec struct {
+	Name                    string
+	Title                   string
+	ObservedThroughputLabel string
+	UsesSinkMetrics         bool
+}
+
+var benchmarkModeSpecs = map[string]benchmarkModeSpec{
+	"request-reply": {
+		Name:                    "request-reply",
+		Title:                   "Request-Reply",
+		ObservedThroughputLabel: "Observed Node Throughput",
+		UsesSinkMetrics:         true,
+	},
+	"fire-and-forget": {
+		Name:                    "fire-and-forget",
+		Title:                   "Fire-And-Forget",
+		ObservedThroughputLabel: "Observed Node Throughput",
+		UsesSinkMetrics:         true,
+	},
+	"write": {
+		Name:                    "write",
+		Title:                   "Write",
+		ObservedThroughputLabel: "Sender Write Throughput",
+		UsesSinkMetrics:         false,
+	},
+}
+
+type benchmarkRow struct {
+	Mode                 string
+	Clients              int
+	Size                 int
+	Rate                 int
+	Repeat               int
+	SenderTotalMessages  int64
+	SenderMPS            float64
+	SenderMeanLatencyMS  float64
+	SenderP50LatencyMS   float64
+	SenderP99LatencyMS   float64
+	SenderRuntimeErrors  int64
+	SinkReceivedMessages int64
+	SinkErrors           int64
+	SinkActiveReceiveMPS float64
+	NodeCPUPercent       float64
+	TotalCPUPercent      float64
+}
+
+type slimRepoCSVRow struct {
+	Senders           int
+	MessagesPerSender int
+	PayloadBytes      int
+	TotalMessages     int64
+	Run               int
+	SendElapsedS      float64
+	TotalElapsedS     float64
+	TotalReceived     int64
+	SendMPS           float64
+	RecvMPS           float64
+}
+
+type sampleStats struct {
+	Count    int
+	Mean     float64
+	Variance float64
+	CILow    float64
+	CIHigh   float64
+}
+
+type summaryCardView struct {
+	Label  string
+	Value  string
+	Detail string
+}
+
+type tableView struct {
+	Title   string
+	Columns []string
+	Rows    [][]string
+}
+
+type documentView struct {
+	Title string
+	Path  string
+	HTML  template.HTML
+	Open  bool
+}
+
+type artifactLinkView struct {
+	Label string
+	Path  string
+}
+
+type sectionView struct {
+	ID          string
+	Title       string
+	Description string
+	Cards       []summaryCardView
+	Tables      []tableView
+	Documents   []documentView
+	Artifacts   []artifactLinkView
+}
+
+type dashboardView struct {
+	GeneratedAt string
+	Sections    []sectionView
+	HasSections bool
+}
+
+func main() {
+	smokeDir := flag.String("smoke-dir", "", "directory containing the benchmark smoke report bundle")
+	capacityDir := flag.String("capacity-dir", "", "directory containing the benchmark capacity report bundle")
+	slimCSV := flag.String("slim-csv", "", "path to an optional agntcy/slim benchmark-results.csv file")
+	basicCSV := flag.String("basic-csv", "", "path to a CSIT-produced basic-benchmark-results.csv file")
+	minCIRuns := flag.Int("min-ci-runs", defaultMinimumConfidenceIntervalRuns, "minimum repeated runs required before confidence intervals are shown")
+	outputPath := flag.String("output", "./reports/index.html", "path to the generated HTML dashboard")
+	flag.Parse()
+	if *minCIRuns > 0 {
+		configuredMinimumConfidenceIntervalRuns = *minCIRuns
+	}
+
+	view, err := buildDashboard(*smokeDir, *capacityDir, *slimCSV, *basicCSV, *outputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build dashboard: %v\n", err)
+		os.Exit(1)
+	}
+
+	htmlOutput, err := renderDashboard(view)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "render dashboard: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outputPath), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "create output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*outputPath, htmlOutput, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write dashboard: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s\n", *outputPath)
+}
+
+func buildDashboard(smokeDir string, capacityDir string, slimCSV string, basicCSV string, outputPath string) (dashboardView, error) {
+	outputDir := filepath.Dir(outputPath)
+	view := dashboardView{GeneratedAt: time.Now().Format("2006-01-02 15:04:05 MST")}
+
+	if section, ok, err := buildSmokeSection(smokeDir, outputDir); err != nil {
+		return dashboardView{}, err
+	} else if ok {
+		view.Sections = append(view.Sections, section)
+	}
+
+	if section, ok, err := buildCapacitySection(capacityDir, outputDir); err != nil {
+		return dashboardView{}, err
+	} else if ok {
+		view.Sections = append(view.Sections, section)
+	}
+
+	if section, ok, err := buildBasicBenchmarkSection(basicCSV, outputDir); err != nil {
+		return dashboardView{}, err
+	} else if ok {
+		view.Sections = append(view.Sections, section)
+	}
+
+	if section, ok, err := buildSlimRepoSection(slimCSV, outputDir); err != nil {
+		return dashboardView{}, err
+	} else if ok {
+		view.Sections = append(view.Sections, section)
+	}
+
+	view.HasSections = len(view.Sections) > 0
+	return view, nil
+}
+
+func buildSmokeSection(smokeDir string, outputDir string) (sectionView, bool, error) {
+	if smokeDir == "" {
+		return sectionView{}, false, nil
+	}
+	if _, err := os.Stat(smokeDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return sectionView{}, false, nil
+		}
+		return sectionView{}, false, err
+	}
+
+	rows, err := readBenchmarkTSV(filepath.Join(smokeDir, "results.tsv"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return sectionView{}, false, err
+	}
+
+	section := sectionView{
+		ID:          "smoke-suite",
+		Title:       "CSIT SLIM Smoke Suite",
+		Description: "Repeated benchmark results for the CSIT smoke matrix across request-reply, fire-and-forget, and write workloads.",
+		Cards:       buildSmokeCards(rows),
+		Tables:      buildModeTables(rows),
+		Artifacts:   collectArtifactLinks(smokeDir, outputDir, []string{"index.html", "results.tsv", "suite_summary.md", "technical_report.md", "ci-smoke-report.md", "ci-smoke.log"}),
+	}
+	section.Documents, err = collectDocuments(smokeDir, outputDir, []documentSpec{{Title: "Suite Summary", FileName: "suite_summary.md", Open: true}, {Title: "Technical Report", FileName: "technical_report.md", Open: false}, {Title: "CI Smoke Report", FileName: "ci-smoke-report.md", Open: false}})
+	if err != nil {
+		return sectionView{}, false, err
+	}
+
+	if len(rows) == 0 && len(section.Documents) == 0 && len(section.Artifacts) == 0 {
+		return sectionView{}, false, nil
+	}
+	return section, true, nil
+}
+
+func buildCapacitySection(capacityDir string, outputDir string) (sectionView, bool, error) {
+	if capacityDir == "" {
+		return sectionView{}, false, nil
+	}
+	if _, err := os.Stat(capacityDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return sectionView{}, false, nil
+		}
+		return sectionView{}, false, err
+	}
+
+	rows, err := readCapacityRows(capacityDir)
+	if err != nil {
+		return sectionView{}, false, err
+	}
+
+	section := sectionView{
+		ID:          "capacity-suite",
+		Title:       "CSIT SLIM Capacity Sweeps",
+		Description: "Adaptive capacity sweeps across sink-backed and write workloads, rendered from the published markdown reports and per-mode TSV samples.",
+		Cards:       buildCapacityCards(rows),
+		Tables:      buildModeTables(rows),
+		Artifacts:   collectArtifactLinks(capacityDir, outputDir, []string{"index.html", "capacity_sweep.md", "capacity-fire-and-forget.md", "capacity-request-reply.md", "capacity-write.md", "results-fire-and-forget.tsv", "results-request-reply.tsv", "results-write.tsv", "ci-capacity-report.md", "ci-capacity.log"}),
+	}
+	section.Documents, err = collectDocuments(capacityDir, outputDir, []documentSpec{{Title: "Adaptive Capacity Sweep", FileName: "capacity_sweep.md", Open: true}, {Title: "Fire-And-Forget Capacity", FileName: "capacity-fire-and-forget.md", Open: false}, {Title: "Request-Reply Capacity", FileName: "capacity-request-reply.md", Open: false}, {Title: "Write Capacity", FileName: "capacity-write.md", Open: false}, {Title: "CI Capacity Report", FileName: "ci-capacity-report.md", Open: false}})
+	if err != nil {
+		return sectionView{}, false, err
+	}
+
+	if len(rows) == 0 && len(section.Documents) == 0 && len(section.Artifacts) == 0 {
+		return sectionView{}, false, nil
+	}
+	return section, true, nil
+}
+
+func buildSlimRepoSection(slimCSV string, outputDir string) (sectionView, bool, error) {
+	if slimCSV == "" {
+		return sectionView{}, false, nil
+	}
+	rows, err := readSlimRepoCSV(slimCSV)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return sectionView{}, false, nil
+		}
+		return sectionView{}, false, err
+	}
+	if len(rows) == 0 {
+		return sectionView{}, false, nil
+	}
+
+	artifactPath, err := relativePath(outputDir, slimCSV)
+	if err != nil {
+		return sectionView{}, false, err
+	}
+
+	section := sectionView{
+		ID:          "slim-repo",
+		Title:       "SLIM Repo Data-Plane Benchmark",
+		Description: "Optional in-process throughput results imported from the agntcy/slim benchmark workflow for side-by-side visibility on the same Pages site.",
+		Cards:       buildSlimRepoCards(rows),
+		Tables:      []tableView{buildSlimRepoTable(rows)},
+		Artifacts:   []artifactLinkView{{Label: "benchmark-results.csv", Path: artifactPath}},
+	}
+	return section, true, nil
+}
+
+func buildBasicBenchmarkSection(basicCSV string, outputDir string) (sectionView, bool, error) {
+	if basicCSV == "" {
+		return sectionView{}, false, nil
+	}
+	rows, err := readSlimRepoCSV(basicCSV)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return sectionView{}, false, nil
+		}
+		return sectionView{}, false, err
+	}
+	if len(rows) == 0 {
+		return sectionView{}, false, nil
+	}
+
+	artifactPath, err := relativePath(outputDir, basicCSV)
+	if err != nil {
+		return sectionView{}, false, err
+	}
+
+	section := sectionView{
+		ID:          "basic-benchmark",
+		Title:       "SLIM Basic Throughput Benchmark",
+		Description: "CSIT-measured baseline throughput results. N senders publish to a single sink over a local SLIM node, with unlimited rate, reproducing the agntcy/slim stress_publish benchmark topology.",
+		Cards:       buildSlimRepoCards(rows),
+		Tables:      []tableView{buildSlimRepoTable(rows)},
+		Artifacts:   []artifactLinkView{{Label: "basic-benchmark-results.csv", Path: artifactPath}},
+	}
+	return section, true, nil
+}
+
+type documentSpec struct {
+	Title    string
+	FileName string
+	Open     bool
+}
+
+func collectDocuments(baseDir string, outputDir string, specs []documentSpec) ([]documentView, error) {
+	docs := make([]documentView, 0, len(specs))
+	for _, spec := range specs {
+		path := filepath.Join(baseDir, spec.FileName)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		relPath, err := relativePath(outputDir, path)
+		if err != nil {
+			return nil, err
+		}
+		htmlContent, err := markdownToHTML(content)
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, documentView{Title: spec.Title, Path: relPath, HTML: htmlContent, Open: spec.Open})
+	}
+	return docs, nil
+}
+
+func markdownToHTML(content []byte) (template.HTML, error) {
+	engine := goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithRendererOptions(rendererhtml.WithUnsafe()),
+	)
+	var buffer bytes.Buffer
+	if err := engine.Convert(content, &buffer); err != nil {
+		return "", err
+	}
+	return template.HTML(buffer.String()), nil
+}
+
+func collectArtifactLinks(baseDir string, outputDir string, files []string) []artifactLinkView {
+	links := make([]artifactLinkView, 0, len(files))
+	for _, name := range files {
+		path := filepath.Join(baseDir, name)
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		relPath, err := relativePath(outputDir, path)
+		if err != nil {
+			continue
+		}
+		links = append(links, artifactLinkView{Label: filepath.Base(name), Path: relPath})
+	}
+	return links
+}
+
+func relativePath(outputDir string, target string) (string, error) {
+	rel, err := filepath.Rel(outputDir, target)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func readCapacityRows(baseDir string) ([]benchmarkRow, error) {
+	rows := make([]benchmarkRow, 0)
+	files := []string{"results-fire-and-forget.tsv", "results-request-reply.tsv", "results-write.tsv"}
+	found := false
+	for _, name := range files {
+		fileRows, err := readBenchmarkTSV(filepath.Join(baseDir, name))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		rows = append(rows, fileRows...)
+		found = true
+	}
+	if found {
+		return rows, nil
+	}
+	return readBenchmarkTSV(filepath.Join(baseDir, "results.tsv"))
+}
+
+func readBenchmarkTSV(path string) ([]benchmarkRow, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.Comma = '\t'
+	reader.FieldsPerRecord = -1
+
+	headers, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	index := makeHeaderIndex(headers)
+
+	required := []string{"mode", "clients", "size", "rate", "repeat", "sender_total_messages", "sender_mps", "sender_mean_latency_ms", "sender_p50_latency_ms", "sender_p99_latency_ms", "sender_runtime_errors", "sink_received_messages", "sink_errors", "sink_active_receive_mps", "node_cpu_percent", "total_cpu_percent"}
+	for _, key := range required {
+		if _, ok := index[key]; !ok {
+			return nil, fmt.Errorf("missing %q header in %s", key, path)
+		}
+	}
+
+	rows := []benchmarkRow{}
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		row := benchmarkRow{
+			Mode:                 field(record, index, "mode"),
+			Clients:              mustParseInt(field(record, index, "clients")),
+			Size:                 mustParseInt(field(record, index, "size")),
+			Rate:                 mustParseInt(field(record, index, "rate")),
+			Repeat:               mustParseInt(field(record, index, "repeat")),
+			SenderTotalMessages:  mustParseInt64(field(record, index, "sender_total_messages")),
+			SenderMPS:            mustParseFloat(field(record, index, "sender_mps")),
+			SenderMeanLatencyMS:  mustParseFloat(field(record, index, "sender_mean_latency_ms")),
+			SenderP50LatencyMS:   mustParseFloat(field(record, index, "sender_p50_latency_ms")),
+			SenderP99LatencyMS:   mustParseFloat(field(record, index, "sender_p99_latency_ms")),
+			SenderRuntimeErrors:  mustParseInt64(field(record, index, "sender_runtime_errors")),
+			SinkReceivedMessages: mustParseInt64(field(record, index, "sink_received_messages")),
+			SinkErrors:           mustParseInt64(field(record, index, "sink_errors")),
+			SinkActiveReceiveMPS: mustParseFloat(field(record, index, "sink_active_receive_mps")),
+			NodeCPUPercent:       mustParseFloat(field(record, index, "node_cpu_percent")),
+			TotalCPUPercent:      mustParseFloat(field(record, index, "total_cpu_percent")),
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func readSlimRepoCSV(path string) ([]slimRepoCSVRow, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+	headers, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	index := makeHeaderIndex(headers)
+	required := []string{"senders", "messages_per_sender", "payload_bytes", "total_messages", "run", "send_elapsed_s", "total_elapsed_s", "total_received", "send_mps", "recv_mps"}
+	for _, key := range required {
+		if _, ok := index[key]; !ok {
+			return nil, fmt.Errorf("missing %q header in %s", key, path)
+		}
+	}
+
+	rows := []slimRepoCSVRow{}
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		rows = append(rows, slimRepoCSVRow{
+			Senders:           mustParseInt(field(record, index, "senders")),
+			MessagesPerSender: mustParseInt(field(record, index, "messages_per_sender")),
+			PayloadBytes:      mustParseInt(field(record, index, "payload_bytes")),
+			TotalMessages:     mustParseInt64(field(record, index, "total_messages")),
+			Run:               mustParseInt(field(record, index, "run")),
+			SendElapsedS:      mustParseFloat(field(record, index, "send_elapsed_s")),
+			TotalElapsedS:     mustParseFloat(field(record, index, "total_elapsed_s")),
+			TotalReceived:     mustParseInt64(field(record, index, "total_received")),
+			SendMPS:           mustParseFloat(field(record, index, "send_mps")),
+			RecvMPS:           mustParseFloat(field(record, index, "recv_mps")),
+		})
+	}
+	return rows, nil
+}
+
+func makeHeaderIndex(headers []string) map[string]int {
+	index := make(map[string]int, len(headers))
+	for i, header := range headers {
+		index[strings.TrimSpace(header)] = i
+	}
+	return index
+}
+
+func field(record []string, index map[string]int, key string) string {
+	position, ok := index[key]
+	if !ok || position >= len(record) {
+		return ""
+	}
+	return strings.TrimSpace(record[position])
+}
+
+func mustParseInt(value string) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0
+	}
+	return parsed
+}
+
+func mustParseInt64(value string) int64 {
+	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
+}
+
+func mustParseFloat(value string) float64 {
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
+}
+
+type caseKey struct {
+	Mode    string
+	Clients int
+	Size    int
+	Rate    int
+}
+
+type caseSummary struct {
+	Key           caseKey
+	Rows          []benchmarkRow
+	Sender        sampleStats
+	Observed      sampleStats
+	MeanLatency   sampleStats
+	P50Latency    sampleStats
+	P99Latency    sampleStats
+	NodeCPU       sampleStats
+	TotalCPU      sampleStats
+	TotalErrors   int64
+	ObservedLabel string
+}
+
+func buildModeTables(rows []benchmarkRow) []tableView {
+	caseSummaries := summarizeCases(rows)
+	byMode := map[string][]caseSummary{}
+	for _, summary := range caseSummaries {
+		byMode[summary.Key.Mode] = append(byMode[summary.Key.Mode], summary)
+	}
+
+	tables := []tableView{}
+	for _, mode := range benchmarkModeOrder {
+		modeRows := byMode[mode]
+		if len(modeRows) == 0 {
+			continue
+		}
+		if mode == "request-reply" {
+			tables = append(tables, buildRequestReplyTable(modeRows))
+			continue
+		}
+		tables = append(tables, buildThroughputTable(modeRows))
+	}
+	return tables
+}
+
+func summarizeCases(rows []benchmarkRow) []caseSummary {
+	grouped := map[caseKey][]benchmarkRow{}
+	for _, row := range rows {
+		key := caseKey{Mode: row.Mode, Clients: row.Clients, Size: row.Size, Rate: row.Rate}
+		grouped[key] = append(grouped[key], row)
+	}
+
+	keys := make([]caseKey, 0, len(grouped))
+	for key := range grouped {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i int, j int) bool {
+		if modeSortIndex(keys[i].Mode) != modeSortIndex(keys[j].Mode) {
+			return modeSortIndex(keys[i].Mode) < modeSortIndex(keys[j].Mode)
+		}
+		if keys[i].Clients != keys[j].Clients {
+			return keys[i].Clients < keys[j].Clients
+		}
+		if keys[i].Size != keys[j].Size {
+			return keys[i].Size < keys[j].Size
+		}
+		return keys[i].Rate < keys[j].Rate
+	})
+
+	summaries := make([]caseSummary, 0, len(keys))
+	for _, key := range keys {
+		rows := grouped[key]
+		totalErrors := int64(0)
+		for _, row := range rows {
+			totalErrors += row.SenderRuntimeErrors + row.SinkErrors
+		}
+		summaries = append(summaries, caseSummary{
+			Key:           key,
+			Rows:          rows,
+			Sender:        computeSampleStats(senderValues(rows)),
+			Observed:      computeSampleStats(observedValues(rows)),
+			MeanLatency:   computeSampleStats(meanLatencyValues(rows)),
+			P50Latency:    computeSampleStats(p50LatencyValues(rows)),
+			P99Latency:    computeSampleStats(p99LatencyValues(rows)),
+			NodeCPU:       computeSampleStats(nodeCPUValues(rows)),
+			TotalCPU:      computeSampleStats(totalCPUValues(rows)),
+			TotalErrors:   totalErrors,
+			ObservedLabel: modeObservedThroughputLabel(key.Mode),
+		})
+	}
+	return summaries
+}
+
+func buildThroughputTable(rows []caseSummary) tableView {
+	columns := []string{"Clients", "Payload", "Rate", "Repeats", "Sender Mean msg/sec", "Sender 95% CI", rows[0].ObservedLabel, "Observed 95% CI", "Node CPU %", "Total CPU %", "Errors"}
+	tableRows := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		tableRows = append(tableRows, []string{
+			strconv.Itoa(row.Key.Clients),
+			fmt.Sprintf("%dB", row.Key.Size),
+			strconv.Itoa(row.Key.Rate),
+			strconv.Itoa(len(row.Rows)),
+			formatFloat(row.Sender.Mean),
+			formatCI(row.Sender),
+			formatFloat(row.Observed.Mean),
+			formatCI(row.Observed),
+			formatFloat(row.NodeCPU.Mean),
+			formatFloat(row.TotalCPU.Mean),
+			strconv.FormatInt(row.TotalErrors, 10),
+		})
+	}
+	return tableView{Title: fmt.Sprintf("%s Results", modeDisplayTitle(rows[0].Key.Mode)), Columns: columns, Rows: tableRows}
+}
+
+func buildRequestReplyTable(rows []caseSummary) tableView {
+	columns := []string{"Clients", "Payload", "Rate", "Repeats", "Mean Latency ms", "Mean 95% CI", "P50 Latency ms", "P50 95% CI", "P99 Latency ms", "P99 95% CI", "Node CPU %", "Errors"}
+	tableRows := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		tableRows = append(tableRows, []string{
+			strconv.Itoa(row.Key.Clients),
+			fmt.Sprintf("%dB", row.Key.Size),
+			strconv.Itoa(row.Key.Rate),
+			strconv.Itoa(len(row.Rows)),
+			formatFloat(row.MeanLatency.Mean),
+			formatCI(row.MeanLatency),
+			formatFloat(row.P50Latency.Mean),
+			formatCI(row.P50Latency),
+			formatFloat(row.P99Latency.Mean),
+			formatCI(row.P99Latency),
+			formatFloat(row.NodeCPU.Mean),
+			strconv.FormatInt(row.TotalErrors, 10),
+		})
+	}
+	return tableView{Title: fmt.Sprintf("%s Results", modeDisplayTitle(rows[0].Key.Mode)), Columns: columns, Rows: tableRows}
+}
+
+func buildSmokeCards(rows []benchmarkRow) []summaryCardView {
+	if len(rows) == 0 {
+		return []summaryCardView{{Label: "Smoke data", Value: "Unavailable", Detail: "No smoke TSV artifact was found in this report bundle."}}
+	}
+	caseSummaries := summarizeCases(rows)
+	bestObserved := bestObservedCase(caseSummaries)
+	lowestLatency := lowestLatencyCase(caseSummaries)
+	totalErrors := int64(0)
+	for _, row := range rows {
+		totalErrors += row.SenderRuntimeErrors + row.SinkErrors
+	}
+	cards := []summaryCardView{{Label: "Repeated measurements", Value: strconv.Itoa(len(rows)), Detail: fmt.Sprintf("%d unique benchmark cases across %d modes.", len(caseSummaries), countModes(rows))}, {Label: "Best observed throughput", Value: formatFloat(bestObserved.Observed.Mean) + " msg/sec", Detail: describeCase(bestObserved.Key)}, {Label: "Total runtime errors", Value: strconv.FormatInt(totalErrors, 10), Detail: "Combined sender and sink runtime error count."}}
+	if lowestLatency.Key.Mode != "" {
+		cards = append(cards, summaryCardView{Label: "Lowest P50 latency", Value: formatFloat(lowestLatency.P50Latency.Mean) + " ms", Detail: describeCase(lowestLatency.Key)})
+	}
+	return cards
+}
+
+func buildCapacityCards(rows []benchmarkRow) []summaryCardView {
+	if len(rows) == 0 {
+		return []summaryCardView{{Label: "Capacity data", Value: "Rendered from markdown", Detail: "Structured TSV samples were not found, so the dashboard falls back to the published capacity markdown."}}
+	}
+	caseSummaries := summarizeCases(rows)
+	bestObserved := bestObservedCase(caseSummaries)
+	totalErrors := int64(0)
+	for _, row := range rows {
+		totalErrors += row.SenderRuntimeErrors + row.SinkErrors
+	}
+	cards := []summaryCardView{{Label: "Capacity mode samples", Value: strconv.Itoa(len(rows)), Detail: fmt.Sprintf("%d unique sampled cases across %d modes.", len(caseSummaries), countModes(rows))}, {Label: "Strongest measured throughput", Value: formatFloat(bestObserved.Observed.Mean) + " msg/sec", Detail: describeCase(bestObserved.Key)}, {Label: "Total runtime errors", Value: strconv.FormatInt(totalErrors, 10), Detail: "Combined sender and sink runtime error count from the sampled capacity runs."}}
+	if latency := lowestLatencyCase(caseSummaries); latency.Key.Mode != "" {
+		cards = append(cards, summaryCardView{Label: "Request-reply P50 latency", Value: formatFloat(latency.P50Latency.Mean) + " ms", Detail: describeCase(latency.Key)})
+	}
+	return cards
+}
+
+func buildSlimRepoCards(rows []slimRepoCSVRow) []summaryCardView {
+	if len(rows) == 0 {
+		return nil
+	}
+	grouped := summarizeSlimRepoRows(rows)
+	bestRecv := grouped[0]
+	bestSend := grouped[0]
+	bestDelivery := grouped[0]
+	for _, row := range grouped[1:] {
+		if row.RecvMPS.Mean > bestRecv.RecvMPS.Mean {
+			bestRecv = row
+		}
+		if row.SendMPS.Mean > bestSend.SendMPS.Mean {
+			bestSend = row
+		}
+		if row.DeliveryPct.Mean > bestDelivery.DeliveryPct.Mean {
+			bestDelivery = row
+		}
+	}
+	return []summaryCardView{{Label: "Configurations", Value: strconv.Itoa(len(grouped)), Detail: fmt.Sprintf("%d raw CSV samples imported from agntcy/slim.", len(rows))}, {Label: "Best receive throughput", Value: formatFloat(bestRecv.RecvMPS.Mean) + " msg/sec", Detail: describeSlimRepoCase(bestRecv.Key)}, {Label: "Best send throughput", Value: formatFloat(bestSend.SendMPS.Mean) + " msg/sec", Detail: describeSlimRepoCase(bestSend.Key)}, {Label: "Highest delivery", Value: formatFloat(bestDelivery.DeliveryPct.Mean) + "%", Detail: describeSlimRepoCase(bestDelivery.Key)}}
+}
+
+func bestObservedCase(rows []caseSummary) caseSummary {
+	best := caseSummary{}
+	for _, row := range rows {
+		if row.Observed.Mean > best.Observed.Mean {
+			best = row
+		}
+	}
+	return best
+}
+
+func lowestLatencyCase(rows []caseSummary) caseSummary {
+	best := caseSummary{}
+	initialized := false
+	for _, row := range rows {
+		if row.Key.Mode != "request-reply" || row.P50Latency.Count == 0 {
+			continue
+		}
+		if !initialized || row.P50Latency.Mean < best.P50Latency.Mean {
+			best = row
+			initialized = true
+		}
+	}
+	return best
+}
+
+func countModes(rows []benchmarkRow) int {
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		seen[row.Mode] = struct{}{}
+	}
+	return len(seen)
+}
+
+func describeCase(key caseKey) string {
+	if key.Mode == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s, %d client(s), %dB payload, %d msg/sec.", modeDisplayTitle(key.Mode), key.Clients, key.Size, key.Rate)
+}
+
+func modeDisplayTitle(mode string) string {
+	if spec, ok := benchmarkModeSpecs[mode]; ok {
+		return spec.Title
+	}
+	return strings.Title(mode)
+}
+
+func modeObservedThroughputLabel(mode string) string {
+	if spec, ok := benchmarkModeSpecs[mode]; ok {
+		return spec.ObservedThroughputLabel
+	}
+	return "Observed Throughput"
+}
+
+func modeSortIndex(mode string) int {
+	for i, candidate := range benchmarkModeOrder {
+		if candidate == mode {
+			return i
+		}
+	}
+	return len(benchmarkModeOrder)
+}
+
+func senderValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, row.SenderMPS)
+	}
+	return values
+}
+
+func observedValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		if row.Mode == "write" {
+			values = append(values, row.SenderMPS)
+			continue
+		}
+		values = append(values, row.SinkActiveReceiveMPS)
+	}
+	return values
+}
+
+func meanLatencyValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		if row.SenderMeanLatencyMS > 0 {
+			values = append(values, row.SenderMeanLatencyMS)
+		}
+	}
+	return values
+}
+
+func p50LatencyValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		if row.SenderP50LatencyMS > 0 {
+			values = append(values, row.SenderP50LatencyMS)
+		}
+	}
+	return values
+}
+
+func p99LatencyValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		if row.SenderP99LatencyMS > 0 {
+			values = append(values, row.SenderP99LatencyMS)
+		}
+	}
+	return values
+}
+
+func nodeCPUValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, row.NodeCPUPercent)
+	}
+	return values
+}
+
+func totalCPUValues(rows []benchmarkRow) []float64 {
+	values := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, row.TotalCPUPercent)
+	}
+	return values
+}
+
+func computeSampleStats(values []float64) sampleStats {
+	count := len(values)
+	if count == 0 {
+		return sampleStats{}
+	}
+	mean := stat.Mean(values, nil)
+	if count == 1 {
+		return sampleStats{Count: 1, Mean: mean, Variance: 0, CILow: mean, CIHigh: mean}
+	}
+	variance := stat.Variance(values, nil)
+	stddev := stat.StdDev(values, nil)
+	standardError := stddev / math.Sqrt(float64(count))
+	tDist := distuv.StudentsT{Mu: mean, Sigma: standardError, Nu: float64(count - 1)}
+	tailProbability := confidenceIntervalAlpha / 2
+	ciLow := math.Max(0, tDist.Quantile(tailProbability))
+	ciHigh := tDist.Quantile(1 - tailProbability)
+	return sampleStats{Count: count, Mean: mean, Variance: variance, CILow: ciLow, CIHigh: ciHigh}
+}
+
+func confidenceIntervalAvailable(count int) bool {
+	return count >= configuredMinimumConfidenceIntervalRuns
+}
+
+func unavailableConfidenceIntervalLabel() string {
+	return fmt.Sprintf("n/a (need >=%d runs)", configuredMinimumConfidenceIntervalRuns)
+}
+
+func formatCI(stats sampleStats) string {
+	if stats.Count == 0 {
+		return "-"
+	}
+	if !confidenceIntervalAvailable(stats.Count) {
+		return unavailableConfidenceIntervalLabel()
+	}
+	return fmt.Sprintf("[%s, %s]", formatFloat(stats.CILow), formatFloat(stats.CIHigh))
+}
+
+func formatFloat(value float64) string {
+	return fmt.Sprintf("%.2f", value)
+}
+
+type slimRepoCaseKey struct {
+	Senders           int
+	PayloadBytes      int
+	MessagesPerSender int
+}
+
+type slimRepoCaseSummary struct {
+	Key          slimRepoCaseKey
+	Rows         []slimRepoCSVRow
+	SendMPS      sampleStats
+	RecvMPS      sampleStats
+	DeliveryPct  sampleStats
+	SendElapsed  sampleStats
+	TotalElapsed sampleStats
+}
+
+func summarizeSlimRepoRows(rows []slimRepoCSVRow) []slimRepoCaseSummary {
+	grouped := map[slimRepoCaseKey][]slimRepoCSVRow{}
+	for _, row := range rows {
+		key := slimRepoCaseKey{Senders: row.Senders, PayloadBytes: row.PayloadBytes, MessagesPerSender: row.MessagesPerSender}
+		grouped[key] = append(grouped[key], row)
+	}
+
+	keys := make([]slimRepoCaseKey, 0, len(grouped))
+	for key := range grouped {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i int, j int) bool {
+		if keys[i].Senders != keys[j].Senders {
+			return keys[i].Senders < keys[j].Senders
+		}
+		return keys[i].PayloadBytes < keys[j].PayloadBytes
+	})
+
+	summaries := make([]slimRepoCaseSummary, 0, len(keys))
+	for _, key := range keys {
+		group := grouped[key]
+		delivery := make([]float64, 0, len(group))
+		sendElapsed := make([]float64, 0, len(group))
+		totalElapsed := make([]float64, 0, len(group))
+		sendMPS := make([]float64, 0, len(group))
+		recvMPS := make([]float64, 0, len(group))
+		for _, row := range group {
+			sendElapsed = append(sendElapsed, row.SendElapsedS)
+			totalElapsed = append(totalElapsed, row.TotalElapsedS)
+			sendMPS = append(sendMPS, row.SendMPS)
+			recvMPS = append(recvMPS, row.RecvMPS)
+			if row.TotalMessages > 0 {
+				delivery = append(delivery, 100*float64(row.TotalReceived)/float64(row.TotalMessages))
+			}
+		}
+		summaries = append(summaries, slimRepoCaseSummary{Key: key, Rows: group, SendMPS: computeSampleStats(sendMPS), RecvMPS: computeSampleStats(recvMPS), DeliveryPct: computeSampleStats(delivery), SendElapsed: computeSampleStats(sendElapsed), TotalElapsed: computeSampleStats(totalElapsed)})
+	}
+	return summaries
+}
+
+func buildSlimRepoTable(rows []slimRepoCSVRow) tableView {
+	summaries := summarizeSlimRepoRows(rows)
+	tableRows := make([][]string, 0, len(summaries))
+	for _, summary := range summaries {
+		tableRows = append(tableRows, []string{
+			strconv.Itoa(summary.Key.Senders),
+			fmt.Sprintf("%dB", summary.Key.PayloadBytes),
+			strconv.Itoa(summary.Key.MessagesPerSender),
+			strconv.Itoa(len(summary.Rows)),
+			formatFloat(summary.SendMPS.Mean),
+			formatFloat(summary.RecvMPS.Mean),
+			formatFloat(summary.DeliveryPct.Mean) + "%",
+			formatFloat(summary.SendElapsed.Mean) + "s",
+			formatFloat(summary.TotalElapsed.Mean) + "s",
+		})
+	}
+	return tableView{Title: "Data-Plane Benchmark CSV Summary", Columns: []string{"Senders", "Payload", "Messages/Sender", "Runs", "Avg Send MPS", "Avg Receive MPS", "Avg Delivery", "Avg Send Elapsed", "Avg Total Elapsed"}, Rows: tableRows}
+}
+
+func describeSlimRepoCase(key slimRepoCaseKey) string {
+	return fmt.Sprintf("%d senders, %dB payload, %d messages per sender.", key.Senders, key.PayloadBytes, key.MessagesPerSender)
+}
+
+func renderDashboard(view dashboardView) ([]byte, error) {
+	tmpl, err := template.New("benchmark-dashboard").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SLIM Benchmark Dashboard</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f3eee4;
+      --panel: rgba(255, 252, 246, 0.94);
+      --panel-strong: rgba(255, 255, 255, 0.92);
+      --text: #1d2731;
+      --muted: #5b6773;
+      --accent: #0f766e;
+      --accent-strong: #134e4a;
+      --warm: #b45309;
+      --border: rgba(15, 118, 110, 0.18);
+      --shadow: 0 28px 70px rgba(29, 39, 49, 0.12);
+      --code: #f3f6f8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(15, 118, 110, 0.15), transparent 28%),
+        radial-gradient(circle at bottom right, rgba(180, 83, 9, 0.14), transparent 22%),
+        linear-gradient(180deg, #faf7f2 0%, var(--bg) 100%);
+      padding: 40px 18px 56px;
+    }
+    main {
+      max-width: 1180px;
+      margin: 0 auto;
+      display: grid;
+      gap: 24px;
+    }
+    .hero, .section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      box-shadow: var(--shadow);
+      padding: 32px;
+    }
+    .hero h1 {
+      margin: 0 0 12px;
+      font-size: clamp(2.7rem, 4vw, 4.5rem);
+      line-height: 0.92;
+      letter-spacing: -0.05em;
+      max-width: 12ch;
+    }
+    .eyebrow {
+      display: inline-block;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-size: 0.78rem;
+      color: var(--accent);
+      margin-bottom: 14px;
+    }
+    .lead {
+      font-size: 1.08rem;
+      line-height: 1.75;
+      color: var(--muted);
+      max-width: 70ch;
+      margin: 0;
+    }
+    .nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 24px;
+    }
+    .nav a, .artifact-list a {
+      color: var(--accent-strong);
+      text-decoration: none;
+    }
+    .nav a {
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: rgba(15, 118, 110, 0.08);
+      border: 1px solid rgba(15, 118, 110, 0.14);
+      font-size: 0.95rem;
+    }
+    .meta {
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 0.94rem;
+    }
+    .section-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: flex-start;
+      margin-bottom: 18px;
+    }
+    .section h2 {
+      margin: 0 0 8px;
+      font-size: clamp(1.7rem, 2.2vw, 2.4rem);
+      letter-spacing: -0.04em;
+    }
+    .section p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.7;
+    }
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 14px;
+      margin: 20px 0 24px;
+    }
+    .card {
+      background: var(--panel-strong);
+      border: 1px solid rgba(15, 118, 110, 0.12);
+      border-radius: 22px;
+      padding: 18px;
+    }
+    .card .label {
+      color: var(--muted);
+      font-size: 0.92rem;
+      display: block;
+      margin-bottom: 8px;
+    }
+    .card .value {
+      display: block;
+      font-size: 1.55rem;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      margin-bottom: 8px;
+    }
+    .card .detail {
+      color: var(--muted);
+      font-size: 0.92rem;
+      line-height: 1.55;
+    }
+    .table-stack {
+      display: grid;
+      gap: 18px;
+      margin-bottom: 22px;
+    }
+    .table-panel {
+      background: rgba(255, 255, 255, 0.74);
+      border: 1px solid rgba(15, 118, 110, 0.12);
+      border-radius: 22px;
+      overflow: hidden;
+    }
+    .table-panel h3 {
+      margin: 0;
+      padding: 18px 20px 0;
+      font-size: 1.18rem;
+    }
+    .table-wrap {
+      overflow-x: auto;
+      padding: 14px 18px 18px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.95rem;
+    }
+    th, td {
+      text-align: left;
+      padding: 12px 10px;
+      border-bottom: 1px solid rgba(15, 118, 110, 0.1);
+      vertical-align: top;
+    }
+    th {
+      color: var(--accent-strong);
+      font-size: 0.84rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    details {
+      background: rgba(255, 255, 255, 0.76);
+      border: 1px solid rgba(15, 118, 110, 0.12);
+      border-radius: 22px;
+      padding: 0 18px 18px;
+      margin-bottom: 14px;
+    }
+    summary {
+      cursor: pointer;
+      list-style: none;
+      padding: 18px 0;
+      font-weight: 700;
+      color: var(--accent-strong);
+    }
+    summary::-webkit-details-marker { display: none; }
+    .doc-link {
+      display: inline-block;
+      margin-left: 10px;
+      color: var(--warm);
+      font-size: 0.9rem;
+      text-decoration: none;
+    }
+    .markdown {
+      color: var(--text);
+      line-height: 1.7;
+    }
+    .markdown h1, .markdown h2, .markdown h3, .markdown h4 {
+      letter-spacing: -0.03em;
+      margin-top: 1.6em;
+      margin-bottom: 0.55em;
+    }
+    .markdown h1:first-child, .markdown h2:first-child, .markdown h3:first-child, .markdown h4:first-child {
+      margin-top: 0;
+    }
+    .markdown p, .markdown li { color: var(--text); }
+    .markdown ul, .markdown ol { padding-left: 1.35rem; }
+    .markdown code {
+      background: var(--code);
+      padding: 0.14rem 0.34rem;
+      border-radius: 6px;
+      font-size: 0.92em;
+    }
+    .markdown pre {
+      overflow-x: auto;
+      background: #15212b;
+      color: #f2f5f7;
+      padding: 16px;
+      border-radius: 16px;
+    }
+    .markdown table {
+      display: block;
+      overflow-x: auto;
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+    .markdown thead th {
+      position: sticky;
+      top: 0;
+      background: rgba(15, 118, 110, 0.06);
+    }
+    .artifact-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 14px;
+    }
+    .artifact-list a {
+      padding: 8px 12px;
+      background: rgba(15, 118, 110, 0.08);
+      border-radius: 999px;
+      border: 1px solid rgba(15, 118, 110, 0.14);
+      font-size: 0.92rem;
+    }
+    .empty-state {
+      padding: 22px;
+      border-radius: 22px;
+      background: rgba(255,255,255,0.74);
+      border: 1px dashed rgba(15,118,110,0.24);
+      color: var(--muted);
+      line-height: 1.7;
+    }
+    @media (max-width: 720px) {
+      body { padding: 18px 12px 30px; }
+      .hero, .section { padding: 22px 18px; border-radius: 24px; }
+      .section-head { display: block; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <div class="eyebrow">Static Benchmark Dashboard</div>
+      <h1>SLIM benchmark reports.</h1>
+	<p class="lead">This dashboard turns the benchmark artifacts into a browsable report surface. It keeps the raw markdown, logs, and TSV or CSV files one click away, while surfacing the benchmark tables and summary statistics in HTML. Confidence intervals are shown only when a case has at least 20 repeated runs.</p>
+      <div class="nav">
+        {{range .Sections}}<a href="#{{.ID}}">{{.Title}}</a>{{end}}
+      </div>
+      <div class="meta">Generated: {{.GeneratedAt}}</div>
+    </section>
+    {{if .HasSections}}
+      {{range .Sections}}
+      <section class="section" id="{{.ID}}">
+        <div class="section-head">
+          <div>
+            <h2>{{.Title}}</h2>
+            <p>{{.Description}}</p>
+          </div>
+        </div>
+        {{if .Cards}}
+        <div class="card-grid">
+          {{range .Cards}}
+          <article class="card">
+            <span class="label">{{.Label}}</span>
+            <span class="value">{{.Value}}</span>
+            <span class="detail">{{.Detail}}</span>
+          </article>
+          {{end}}
+        </div>
+        {{end}}
+        {{if .Tables}}
+        <div class="table-stack">
+          {{range .Tables}}
+          <section class="table-panel">
+            <h3>{{.Title}}</h3>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>{{range .Columns}}<th>{{.}}</th>{{end}}</tr>
+                </thead>
+                <tbody>
+                  {{range .Rows}}
+                  <tr>{{range .}}<td>{{.}}</td>{{end}}</tr>
+                  {{end}}
+                </tbody>
+              </table>
+            </div>
+          </section>
+          {{end}}
+        </div>
+        {{end}}
+        {{range .Documents}}
+        <details {{if .Open}}open{{end}}>
+          <summary>{{.Title}} <a class="doc-link" href="{{.Path}}">raw file</a></summary>
+          <div class="markdown">{{.HTML}}</div>
+        </details>
+        {{end}}
+        {{if .Artifacts}}
+        <div class="artifact-list">
+          {{range .Artifacts}}<a href="{{.Path}}">{{.Label}}</a>{{end}}
+        </div>
+        {{end}}
+      </section>
+      {{end}}
+    {{else}}
+      <section class="section">
+        <div class="empty-state">No benchmark artifacts were found. Generate the SLIM benchmark reports first, then rerun the dashboard renderer.</div>
+      </section>
+    {{end}}
+  </main>
+</body>
+</html>`)
+	if err != nil {
+		return nil, err
+	}
+	var buffer bytes.Buffer
+	if err := tmpl.Execute(&buffer, view); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}

--- a/benchmarks/agntcy-slim/tools/report_dashboard_test.go
+++ b/benchmarks/agntcy-slim/tools/report_dashboard_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const benchmarkTSVHeader = "mode\tclients\tsize\trate\trepeat\tsender_total_messages\tsender_mps\tsender_mean_latency_ms\tsender_p50_latency_ms\tsender_p90_latency_ms\tsender_p99_latency_ms\tsender_max_latency_ms\tsender_runtime_errors\tsender_duration\tsink_received_messages\tsink_errors\tsink_receive_mps\tsink_active_receive_mps\tsink_elapsed_seconds\tsink_active_receive_seconds\tsender_cpu_seconds\tsender_cpu_percent\tresponder_cpu_seconds\tresponder_cpu_percent\tnode_cpu_seconds\tnode_cpu_percent\ttotal_cpu_seconds\ttotal_cpu_percent"
+
+func TestBuildDashboardWithSmokeCapacityAndSlimRepo(t *testing.T) {
+	tempDir := t.TempDir()
+	smokeDir := filepath.Join(tempDir, "smoke")
+	capacityDir := filepath.Join(tempDir, "capacity")
+	externalDir := filepath.Join(tempDir, "external")
+	if err := os.MkdirAll(smokeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(capacityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(externalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	smokeRows := []string{benchmarkTSVHeader}
+	smokeRows = append(smokeRows, buildRepeatedBenchmarkRows("request-reply", 1, 16, 100, defaultMinimumConfidenceIntervalRuns, "1s", 98, 99, 2.10, 1.90, 3.30, 22, 46, true)...)
+	smokeRows = append(smokeRows, buildRepeatedBenchmarkRows("fire-and-forget", 1, 16, 1000, defaultMinimumConfidenceIntervalRuns, "1s", 940, 925, 0, 0, 0, 28, 46, true)...)
+	smokeRows = append(smokeRows, buildRepeatedBenchmarkRows("write", 1, 16, 1000, defaultMinimumConfidenceIntervalRuns, "1s", 980, 0, 0, 0, 0, 18, 27, false)...)
+	writeFile(t, filepath.Join(smokeDir, "results.tsv"), strings.Join(smokeRows, "\n"))
+	writeFile(t, filepath.Join(smokeDir, "suite_summary.md"), "# Smoke Summary\n\n| Column | Value |\n| --- | --- |\n| Modes | 3 |\n")
+	writeFile(t, filepath.Join(smokeDir, "technical_report.md"), "# Smoke Technical\n\nRendered markdown body.")
+
+	capacityRows := []string{benchmarkTSVHeader}
+	capacityRows = append(capacityRows, buildRepeatedBenchmarkRows("fire-and-forget", 1, 16384, 128000, defaultMinimumConfidenceIntervalRuns, "5s", 118000, 109500, 0, 0, 0, 42, 74, true)...)
+	writeFile(t, filepath.Join(capacityDir, "results-fire-and-forget.tsv"), strings.Join(capacityRows, "\n"))
+	writeFile(t, filepath.Join(capacityDir, "capacity_sweep.md"), "# Capacity Sweep\n\n## Sink-Backed Modes\n\n| Mode | Best Offered Rate |\n| --- | --- |\n| fire-and-forget | 128000 |\n")
+
+	writeFile(t, filepath.Join(externalDir, "benchmark-results.csv"), strings.Join([]string{
+		"senders,messages_per_sender,payload_bytes,total_messages,run,send_elapsed_s,total_elapsed_s,total_received,send_mps,recv_mps",
+		"1,500000,8,500000,1,0.80,0.95,500000,625000,526315",
+		"4,500000,64,2000000,1,1.90,2.20,1980000,1052631,900000",
+	}, "\n"))
+
+	outputPath := filepath.Join(tempDir, "site", "index.html")
+	view, err := buildDashboard(smokeDir, capacityDir, filepath.Join(externalDir, "benchmark-results.csv"), "", outputPath)
+	if err != nil {
+		t.Fatalf("buildDashboard returned error: %v", err)
+	}
+	html, err := renderDashboard(view)
+	if err != nil {
+		t.Fatalf("renderDashboard returned error: %v", err)
+	}
+	content := string(html)
+	checks := []string{
+		"CSIT SLIM Smoke Suite",
+		"CSIT SLIM Capacity Sweeps",
+		"SLIM Repo Data-Plane Benchmark",
+		"Data-Plane Benchmark CSV Summary",
+		"Confidence intervals are shown only when a case has at least 20 repeated runs.",
+		"Smoke Summary",
+		"Capacity Sweep",
+		"benchmark-results.csv",
+	}
+	for _, check := range checks {
+		if !strings.Contains(content, check) {
+			t.Fatalf("expected HTML to contain %q", check)
+		}
+	}
+}
+
+func TestBuildDashboardWithoutInputsProducesEmptyState(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "index.html")
+	view, err := buildDashboard(filepath.Join(tempDir, "missing-smoke"), filepath.Join(tempDir, "missing-capacity"), filepath.Join(tempDir, "missing.csv"), "", outputPath)
+	if err != nil {
+		t.Fatalf("buildDashboard returned error: %v", err)
+	}
+	html, err := renderDashboard(view)
+	if err != nil {
+		t.Fatalf("renderDashboard returned error: %v", err)
+	}
+	if !strings.Contains(string(html), "No benchmark artifacts were found") {
+		t.Fatalf("expected empty-state text in generated HTML")
+	}
+}
+
+func TestFormatCIRequiresMinimumSampleCount(t *testing.T) {
+	configuredMinimumConfidenceIntervalRuns = defaultMinimumConfidenceIntervalRuns
+	if got := formatCI(sampleStats{Count: defaultMinimumConfidenceIntervalRuns - 1, CILow: 1.23, CIHigh: 4.56}); got != unavailableConfidenceIntervalLabel() {
+		t.Fatalf("formatCI below threshold = %q, want %q", got, unavailableConfidenceIntervalLabel())
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func buildRepeatedBenchmarkRows(mode string, clients int, size int, rate int, repeats int, duration string, baseSenderMPS float64, baseObservedMPS float64, baseMeanLatencyMS float64, baseP50LatencyMS float64, baseP99LatencyMS float64, baseNodeCPUPercent float64, baseTotalCPUPercent float64, hasSink bool) []string {
+	rows := make([]string, 0, repeats)
+	for repeat := 1; repeat <= repeats; repeat++ {
+		jitter := float64((repeat % 5) - 2)
+		senderMPS := baseSenderMPS + jitter
+		observedMPS := 0.0
+		sinkReceivedMessages := int64(0)
+		sinkReceiveMPS := 0.0
+		sinkActiveReceiveMPS := 0.0
+		responderCPUSeconds := 0.0
+		responderCPUPercent := 0.0
+		if hasSink {
+			observedMPS = baseObservedMPS + jitter
+			sinkReceivedMessages = int64(rate)
+			sinkReceiveMPS = observedMPS
+			sinkActiveReceiveMPS = observedMPS
+			responderCPUSeconds = 0.2
+			responderCPUPercent = 8 + jitter/2
+		}
+
+		meanLatency := 0.0
+		p50Latency := 0.0
+		p99Latency := 0.0
+		maxLatency := 0.0
+		if baseMeanLatencyMS > 0 {
+			meanLatency = baseMeanLatencyMS + 0.03*jitter
+			p50Latency = baseP50LatencyMS + 0.02*jitter
+			p99Latency = baseP99LatencyMS + 0.04*jitter
+			maxLatency = p99Latency + 0.8
+		}
+
+		nodeCPUPercent := baseNodeCPUPercent + jitter/2
+		totalCPUPercent := baseTotalCPUPercent + jitter/2
+		rows = append(rows, fmt.Sprintf(
+			"%s\t%d\t%d\t%d\t%d\t%d\t%.2f\t%.2f\t%.2f\t0\t%.2f\t%.2f\t0\t%s\t%d\t0\t%.2f\t%.2f\t1.0\t1.0\t0.3\t%.2f\t%.1f\t%.2f\t0.5\t%.2f\t1.0\t%.2f",
+			mode,
+			clients,
+			size,
+			rate,
+			repeat,
+			rate,
+			senderMPS,
+			meanLatency,
+			p50Latency,
+			p99Latency,
+			maxLatency,
+			duration,
+			sinkReceivedMessages,
+			sinkReceiveMPS,
+			sinkActiveReceiveMPS,
+			8+jitter/2,
+			responderCPUSeconds,
+			responderCPUPercent,
+			nodeCPUPercent,
+			totalCPUPercent,
+		))
+	}
+	return rows
+}

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -3,9 +3,10 @@ module github.com/agntcy/csit/benchmarks
 go 1.24.1
 
 require (
-	gonum.org/v1/gonum v0.16.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
+	github.com/yuin/goldmark v1.8.2
+	gonum.org/v1/gonum v0.16.0
 )
 
 require (

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -22,6 +22,8 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=


### PR DESCRIPTION
## Summary

Adds a Ginkgo test that reproduces the upstream `agntcy/slim` `stress_publish` baseline benchmark natively in CSIT.

### Topology

`N` concurrent senders (`rate-client`, `fire-and-forget` mode, `-rate 0` = unlimited throughput) publish to a single `echo-client` sink, routed through a local `slimctl` SLIM node.

### Benchmark matrix

| Parameter | Values |
|-----------|--------|
| Senders | 1, 2, 4, 8 |
| Payload size | 8, 16, 64, 256, 1024, 4096 bytes |
| Messages per sender | 100K local / 10K CI (configurable) |
| Runs | 3 |

### CSV output schema (matches upstream)

```
senders, messages_per_sender, payload_bytes, total_messages,
run, send_elapsed_s, total_elapsed_s, total_received, send_mps, recv_mps
```

### Changes

- `benchmarks/agntcy-slim/tests/benchmark_basic_test.go` — new Ginkgo test, activated via `SLIM_RUN_BASIC_BENCHMARK=1`
- `benchmarks/agntcy-slim/Taskfile.yml` — `benchmark:basic` and `benchmark:ci:basic` tasks; `BASIC_BENCH_*` vars; `--basic-csv` forwarded in `reports:dashboard`
- `benchmarks/agntcy-slim/tools/report_dashboard.go` — `--basic-csv` flag; new `buildBasicBenchmarkSection` using existing slim-repo CSV reader/rendering
- `.github/workflows/test-benchmarks-slim.yaml` — `slim-benchmark-basic` CI job, uploads `slim-benchmark-basic-report` artifact
- `.github/workflows/publish-test-reports-pages.yaml` — downloads the basic benchmark artifact and passes `--basic-csv` to the dashboard generator

### Publish workflow failure

The `main` branch version of `publish-test-reports-pages` fails when `test-integrations` runs without producing A2A artifacts (no A2A paths changed). This PR's base branch (#178) already contains the full fix with proper `has-a2a` guards. Once #178 merges, the failure will be resolved.

### Stacking

Stacked on `feature/publish-slim-benchmark-pages` (PR #178). Will rebase onto `main` after #178 merges.