### PR TITLE
Analitics/cleanup

### DIFF
--- a/.github/workflows/test-agentic-evidence.yaml
+++ b/.github/workflows/test-agentic-evidence.yaml
@@ -46,6 +46,17 @@ jobs:
           go: true
           go-version: "1.24.4"
 
+      - name: Sync C2 evidence from slim-integration (optional)
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: test-slim-integration.yaml
+          commit: ${{ github.sha }}
+          name: slim-integration-test-result
+          path: integrations/agntcy-slim/topology/reports
+          if_no_artifact_found: ignore
+
       - name: Run agentic evidence tests and build dashboard
         id: agentic-dashboard
         working-directory: analitics

--- a/analitics/README.md
+++ b/analitics/README.md
@@ -74,14 +74,17 @@ analitics/
 │   ├── echo-client/           # Responder/sink helper
 │   └── rate-client/           # Traffic generator
 ├── tests/
-│   ├── c1_evidence_test.go
-│   └── c1_evidence_report.go
+│   ├── suite_test.go              # Ginkgo bootstrap
+│   ├── c1_evidence_test.go        # C1 use-case specs + behavioral assertions
+│   ├── c1_evidence_report.go      # JSON report model + upsert helpers
+│   └── c1_evidence_report_test.go # unit tests for the report helpers
 ├── templates/
 │   └── dashboard.html.tmpl
 ├── scripts/
 │   ├── evidence-lib.sh
 │   ├── render-dashboard.sh
 │   └── render-evidence-report.sh
+├── bin/                       # generated (gitignored): downloaded slimctl
 ├── reports/                   # generated (gitignored)
 └── published/                 # generated (gitignored)
     ├── index.html
@@ -98,12 +101,14 @@ analitics/
 
 ## Status evaluation (C1)
 
-C1 use-case status is derived from `reports/c1-evidence.json`
-(produced by Ginkgo tests in `tests/c1_evidence_test.go`):
+C1 use-case status is read from the `status` field of each case in
+`reports/c1-evidence.json` (produced by Ginkgo tests in `tests/c1_evidence_test.go`):
 
-- `verified` — assertion-based test passed for the mode
-- `failed` — test failed or case reports non-zero errors
-- `unknown` — no case entry for the mode
+- `verified` — the mode's behavioral assertions passed; the test records this case as `verified`
+- `failed` — the case is recorded with a `failed` status
+- `unknown` — no case entry exists for the mode (e.g. the report is missing or the spec did not run)
+
+The render step reads these values as-is; it does not re-run or re-evaluate the tests.
 
 C2/C3 rows use static status until their test evidence is wired into the build flow.
 
@@ -116,7 +121,8 @@ CSIT test reports site under **`docs/agentic-evidence/`** on the `gh-pages` bran
 
 ## Prerequisites
 
-- Go 1.22+
+- Go 1.24+ (matches `go.mod`)
 - `task` in the shell
+- `jq` and `bash` on `PATH` (used by the render scripts)
 - Native SLIM bindings for CGO (`task -t analitics/Taskfile.yml deps:slim-bindings-setup`)
 - `slimctl` on `PATH`, or install via `task -t analitics/Taskfile.yml deps:slimctl-download`

--- a/analitics/README.md
+++ b/analitics/README.md
@@ -98,6 +98,7 @@ analitics/
 
 - Epic: `docs/plans/slim-dashboard-epic.md`
 - C1 contract: `docs/plans/slim-c1-evidence-contract-v1.md`
+- C2 contract: `docs/plans/slim-c2-evidence-contract-v1.md`
 
 ## Status evaluation (C1)
 
@@ -111,6 +112,11 @@ C1 use-case status is read from the `status` field of each case in
 The render step reads these values as-is; it does not re-run or re-evaluate the tests.
 
 C2/C3 rows use static status until their test evidence is wired into the build flow.
+
+**C2 (topology routing):** status for `c2-topology-routing` is read from `c2-evidence.json`
+(produced by TopologyTest in `integrations/agntcy-slim/topology/tests`). Synced into
+`analitics/reports/` automatically from `integrations/agntcy-slim/topology/reports/` during
+`dashboard:sync`. See `docs/plans/slim-c2-evidence-contract-v1.md`.
 
 ## GitHub Pages
 

--- a/analitics/Taskfile.yml
+++ b/analitics/Taskfile.yml
@@ -64,7 +64,7 @@ tasks:
       - mkdir -p "{{.REPORTS_DIR}}" "{{.PUBLISHED_DIR}}/evidence"
 
   dashboard:sync:
-    desc: Copy c1-evidence.json into published/evidence
+    desc: Copy C1/C2 evidence JSON into published/evidence
     deps: [dashboard:prepare]
     cmds:
       - |
@@ -73,9 +73,22 @@ tasks:
         if [ -f "$REPORTS_ABS/c1-evidence.json" ]; then
           cp "$REPORTS_ABS/c1-evidence.json" "{{.PUBLISHED_DIR}}/evidence/c1-evidence.json"
         fi
+        C2_SOURCE="${C2_EVIDENCE_SOURCE:-}"
+        if [ -z "$C2_SOURCE" ] && [ ! -f "$REPORTS_ABS/c2-evidence.json" ]; then
+          TOPOLOGY_C2="../integrations/agntcy-slim/topology/reports/c2-evidence.json"
+          if [ -f "$TOPOLOGY_C2" ]; then
+            C2_SOURCE="$TOPOLOGY_C2"
+          fi
+        fi
+        if [ -n "$C2_SOURCE" ] && [ -f "$C2_SOURCE" ]; then
+          cp "$C2_SOURCE" "$REPORTS_ABS/c2-evidence.json"
+          cp "$C2_SOURCE" "{{.PUBLISHED_DIR}}/evidence/c2-evidence.json"
+        elif [ -f "$REPORTS_ABS/c2-evidence.json" ]; then
+          cp "$REPORTS_ABS/c2-evidence.json" "{{.PUBLISHED_DIR}}/evidence/c2-evidence.json"
+        fi
 
   dashboard:render:
-    desc: Render taxonomy dashboard and C1 evidence reports from JSON
+    desc: Render taxonomy dashboard and evidence reports from JSON
     deps: [dashboard:prepare]
     cmds:
       - |
@@ -88,6 +101,9 @@ tasks:
         REPORTS_DIR="$REPORTS_ABS" \
         OUTPUT_DIR="{{.PUBLISHED_DIR}}/evidence" \
         bash ./scripts/render-evidence-report.sh
+        REPORTS_DIR="$REPORTS_ABS" \
+        OUTPUT_DIR="{{.PUBLISHED_DIR}}/evidence" \
+        bash ./scripts/render-c2-evidence-report.sh
 
   dashboard:build:only:
     desc: Sync evidence JSON and render dashboard (skip test run)
@@ -106,6 +122,9 @@ tasks:
       - rm -f "{{.PUBLISHED_DIR}}/evidence/c1-evidence.json"
       - rm -f "{{.PUBLISHED_DIR}}/evidence/c1-evidence.md"
       - rm -f "{{.PUBLISHED_DIR}}/evidence/c1-evidence.html"
+      - rm -f "{{.PUBLISHED_DIR}}/evidence/c2-evidence.json"
+      - rm -f "{{.PUBLISHED_DIR}}/evidence/c2-evidence.md"
+      - rm -f "{{.PUBLISHED_DIR}}/evidence/c2-evidence.html"
 
   test:agentic-evidence:
     desc: Run all agentic evidence class tests (currently C1 only)

--- a/analitics/scripts/evidence-lib.sh
+++ b/analitics/scripts/evidence-lib.sh
@@ -5,6 +5,18 @@ evidence_json() {
   echo "${REPORTS_DIR}/c1-evidence.json"
 }
 
+c2_evidence_json() {
+  if [[ -n "${C2_EVIDENCE_JSON:-}" ]]; then
+    echo "$C2_EVIDENCE_JSON"
+    return 0
+  fi
+  if [[ -f "${REPORTS_DIR}/c2-evidence.json" ]]; then
+    echo "${REPORTS_DIR}/c2-evidence.json"
+    return 0
+  fi
+  echo "${REPORTS_DIR}/c2-evidence.json"
+}
+
 mode_status() {
   local mode="$1"
   local json_file
@@ -47,12 +59,88 @@ mode_rows() {
   jq -r --arg mode "$mode" '[.cases[] | select(.mode == $mode)] | length' "$json_file" 2>/dev/null || echo "0"
 }
 
+row_status() {
+  local row_id="$1"
+  local expected_scenarios="${2:-0}"
+  local json_file
+  json_file="$(c2_evidence_json)"
+
+  if [[ ! -f "$json_file" ]]; then
+    echo "unknown"
+    return 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "unknown"
+    return 0
+  fi
+
+  local statuses
+  statuses="$(jq -r --arg row_id "$row_id" '[.cases[] | select(.row_id == $row_id) | .status] | .[]' "$json_file" 2>/dev/null)"
+  if [[ -z "$statuses" ]]; then
+    echo "unknown"
+    return 0
+  fi
+
+  local status verified_count=0 failed_count=0 total_count=0
+  while IFS= read -r status; do
+    [[ -z "$status" || "$status" == "null" ]] && continue
+    total_count=$((total_count + 1))
+    case "$status" in
+      failed) failed_count=$((failed_count + 1)) ;;
+      verified) verified_count=$((verified_count + 1)) ;;
+    esac
+  done <<< "$statuses"
+
+  if [[ "$failed_count" -gt 0 ]]; then
+    echo "failed"
+    return 0
+  fi
+  if [[ "$verified_count" -eq 0 ]]; then
+    echo "unknown"
+    return 0
+  fi
+  if [[ "$expected_scenarios" -gt 0 ]]; then
+    if [[ "$verified_count" -eq "$expected_scenarios" ]]; then
+      echo "verified"
+      return 0
+    fi
+    if [[ "$verified_count" -lt "$expected_scenarios" ]]; then
+      echo "partial"
+      return 0
+    fi
+  fi
+  if [[ "$verified_count" -eq "$total_count" ]]; then
+    echo "verified"
+    return 0
+  fi
+  echo "unknown"
+}
+
+row_scenario_count() {
+  local row_id="$1"
+  local json_file
+  json_file="$(c2_evidence_json)"
+
+  if [[ ! -f "$json_file" ]]; then
+    echo "0"
+    return 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "0"
+    return 0
+  fi
+
+  jq -r --arg row_id "$row_id" '[.cases[] | select(.row_id == $row_id)] | length' "$json_file" 2>/dev/null || echo "0"
+}
+
 status_label() {
   case "$1" in
     verified) echo "Verified" ;;
     failed) echo "Failed" ;;
     partial) echo "Partial" ;;
-    planned) echo "Planned" ;;
+    planned) echo "Evidence pending" ;;
     *) echo "Unknown" ;;
   esac
 }

--- a/analitics/scripts/render-c2-evidence-report.sh
+++ b/analitics/scripts/render-c2-evidence-report.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORTS_DIR="${REPORTS_DIR:-$BASE_DIR/reports}"
+OUTPUT_DIR="${OUTPUT_DIR:-$BASE_DIR/published/evidence}"
+
+# shellcheck source=evidence-lib.sh
+source "$BASE_DIR/scripts/evidence-lib.sh"
+
+json_file="$(c2_evidence_json)"
+md_file="${OUTPUT_DIR}/c2-evidence.md"
+html_file="${OUTPUT_DIR}/c2-evidence.html"
+
+if [[ ! -f "$json_file" ]]; then
+  echo "C2 evidence JSON not found: $json_file" >&2
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to render C2 evidence reports" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+cp "$json_file" "${OUTPUT_DIR}/c2-evidence.json"
+
+schema_version="$(jq -r '.schema_version' "$json_file")"
+generated_at="$(jq -r '.generated_at' "$json_file")"
+source_path="$(jq -r '.source' "$json_file")"
+
+render_markdown_case() {
+  local case_json="$1"
+  local row_id scenario status use_case mechanism
+  row_id="$(jq -r '.row_id' <<<"$case_json")"
+  scenario="$(jq -r '.scenario' <<<"$case_json")"
+  status="$(jq -r '.status' <<<"$case_json")"
+  use_case="$(jq -r '.use_case' <<<"$case_json")"
+  mechanism="$(jq -r '.mechanism' <<<"$case_json")"
+
+  {
+    echo "### ${row_id} · ${scenario} — ${status}"
+    echo
+    echo "- **Use case:** ${use_case}"
+    echo "- **Mechanism:** \`${mechanism}\`"
+    echo
+    echo "**Assertions:**"
+    jq -r '.assertions[] | "- \(.)"' <<<"$case_json"
+    echo
+  }
+}
+
+render_html_case() {
+  local case_json="$1"
+  local row_id scenario status use_case mechanism status_class status_label_text
+  row_id="$(jq -r '.row_id' <<<"$case_json")"
+  scenario="$(jq -r '.scenario' <<<"$case_json")"
+  status="$(jq -r '.status' <<<"$case_json")"
+  use_case="$(html_escape "$(jq -r '.use_case' <<<"$case_json")")"
+  mechanism="$(jq -r '.mechanism' <<<"$case_json")"
+  status_class="$(status_css_class "$status")"
+  status_label_text="$(status_label "$status")"
+
+  local assertions_html=""
+  while IFS= read -r assertion; do
+    [[ -z "$assertion" ]] && continue
+    assertions_html+="<li>$(html_escape "$assertion")</li>"
+  done < <(jq -r '.assertions[]' <<<"$case_json")
+
+  cat <<HTML
+    <article class="case-card" id="${row_id}-${scenario}">
+      <div class="case-head">
+        <h2>${row_id} · ${scenario}</h2>
+        <span class="status ${status_class}">${status_label_text}</span>
+      </div>
+      <p class="use-case">${use_case}</p>
+      <p class="mode">Mechanism: <code>${mechanism}</code></p>
+      <h3>Assertions</h3>
+      <ul class="assertions">
+        ${assertions_html}
+      </ul>
+    </article>
+HTML
+}
+
+{
+  echo "# C2 Evidence Report"
+  echo
+  echo "| Field | Value |"
+  echo "|-------|-------|"
+  echo "| Schema version | \`${schema_version}\` |"
+  echo "| Generated at | ${generated_at} |"
+  echo "| Source | \`${source_path}\` |"
+  echo "| Machine-readable | [c2-evidence.json](./c2-evidence.json) |"
+  echo "| HTML | [c2-evidence.html](./c2-evidence.html) |"
+  echo
+  echo "## Scenarios"
+  echo
+  while IFS= read -r case_json; do
+    render_markdown_case "$case_json"
+  done < <(jq -c '.cases[]' "$json_file")
+} > "$md_file"
+
+{
+  cat <<'HTML_HEAD'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>C2 Evidence Report</title>
+  <style>
+    :root {
+      --bg: #f4f6f8; --panel: #fff; --text: #1a2332; --muted: #5a6b7d;
+      --accent: #0d6e6e; --border: #dde3ea;
+      --ok: #1d6b3a; --ok-bg: #e8f5ec; --fail: #9b2c2c; --fail-bg: #fdecec;
+      --partial: #8a6116; --partial-bg: #fef6e8;
+      --unknown: #5a6b7d; --unknown-bg: #eef1f5;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: system-ui, sans-serif; color: var(--text); background: var(--bg); padding: 2rem 1rem 3rem; }
+    main { max-width: 820px; margin: 0 auto; }
+    h1 { margin: 0 0 1rem; }
+    .meta { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.25rem; margin-bottom: 1.5rem; }
+    .meta dl { margin: 0; display: grid; grid-template-columns: 10rem 1fr; gap: .35rem .75rem; font-size: .95rem; }
+    .meta dt { color: var(--muted); font-weight: 600; }
+    .meta a { color: var(--accent); }
+    .case-card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 1.25rem 1.5rem; margin-bottom: 1rem; }
+    .case-head { display: flex; flex-wrap: wrap; align-items: center; gap: .75rem; margin-bottom: .5rem; }
+    .case-head h2 { margin: 0; font-size: 1.15rem; }
+    .use-case { margin: 0 0 .5rem; color: var(--text); }
+    .mode { margin: 0 0 1rem; color: var(--muted); font-size: .9rem; }
+    .assertions { margin: 0; padding-left: 1.2rem; color: var(--text); }
+    .status { display: inline-block; font-size: .8125rem; font-weight: 600; padding: .2rem .55rem; border-radius: 6px; }
+    .status-verified { background: var(--ok-bg); color: var(--ok); }
+    .status-failed { background: var(--fail-bg); color: var(--fail); }
+    .status-partial { background: var(--partial-bg); color: var(--partial); }
+    .status-unknown { background: var(--unknown-bg); color: var(--unknown); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>C2 Evidence Report</h1>
+HTML_HEAD
+
+  echo '    <section class="meta"><dl>'
+  echo "      <dt>Schema version</dt><dd>${schema_version}</dd>"
+  echo "      <dt>Generated at</dt><dd>${generated_at}</dd>"
+  echo "      <dt>Source</dt><dd><code>$(html_escape "$source_path")</code></dd>"
+  echo '      <dt>Formats</dt><dd><a href="./c2-evidence.json">JSON</a> · <a href="./c2-evidence.md">Markdown</a></dd>'
+  echo '    </dl></section>'
+
+  while IFS= read -r case_json; do
+    render_html_case "$case_json"
+  done < <(jq -c '.cases[]' "$json_file")
+
+  cat <<'HTML_FOOT'
+  </main>
+</body>
+</html>
+HTML_FOOT
+} > "$html_file"
+
+echo "Rendered $md_file"
+echo "Rendered $html_file"

--- a/analitics/scripts/render-dashboard.sh
+++ b/analitics/scripts/render-dashboard.sh
@@ -46,6 +46,26 @@ for s in "$c1_rr_status" "$c1_ff_status" "$c1_w_status"; do
 done
 C1_CLASS_STATUS_SPAN="$(render_status_span "$c1_class_status")"
 
+c2_topology_status="$(row_status "c2-topology-routing" 3)"
+c2_topology_scenarios="$(row_scenario_count "c2-topology-routing")"
+C2_TOPOLOGY_STATUS_SPAN="$(render_status_span "$c2_topology_status")"
+
+# C2 class: topology row drives status; workflow row remains pending.
+c2_class_status="unknown"
+case "$c2_topology_status" in
+  verified) c2_class_status="partial" ;;
+  partial) c2_class_status="partial" ;;
+  failed) c2_class_status="failed" ;;
+  *) c2_class_status="unknown" ;;
+esac
+C2_CLASS_STATUS_SPAN="$(render_status_span "$c2_class_status")"
+
+if [[ "$c2_topology_status" == "unknown" ]]; then
+  C2_PLANNED_NOTE='<p class="planned-note"><strong>Forthcoming.</strong> The workflow use case below is not yet wired. Topology routing evidence appears once <code>c2-evidence.json</code> is produced by the topology test. Tracked in the <a href="../docs/plans/slim-dashboard-epic.md">SLIM dashboard epic</a>.</p>'
+else
+  C2_PLANNED_NOTE='<p class="planned-note"><strong>Partial.</strong> Topology routing is assertion-backed below. The workflow-manager use case remains <em>Evidence pending</em>.</p>'
+fi
+
 sed \
   -e "s|{{GENERATED_AT}}|$generated_at|g" \
   -e "s|{{C1_CLASS_STATUS_SPAN}}|$C1_CLASS_STATUS_SPAN|g" \
@@ -55,6 +75,10 @@ sed \
   -e "s|{{C1_RR_ROWS}}|$c1_rr_rows|g" \
   -e "s|{{C1_FF_ROWS}}|$c1_ff_rows|g" \
   -e "s|{{C1_W_ROWS}}|$c1_w_rows|g" \
+  -e "s|{{C2_CLASS_STATUS_SPAN}}|$C2_CLASS_STATUS_SPAN|g" \
+  -e "s|{{C2_TOPOLOGY_STATUS_SPAN}}|$C2_TOPOLOGY_STATUS_SPAN|g" \
+  -e "s|{{C2_TOPOLOGY_SCENARIOS}}|$c2_topology_scenarios|g" \
+  -e "s|{{C2_PLANNED_NOTE}}|$C2_PLANNED_NOTE|g" \
   "$TEMPLATE_FILE" > "$OUTPUT_FILE"
 
 echo "Rendered $OUTPUT_FILE"

--- a/analitics/templates/dashboard.html.tmpl
+++ b/analitics/templates/dashboard.html.tmpl
@@ -55,6 +55,8 @@
     .rerun { font-size: .8125rem; background: var(--panel); border: 1px solid var(--border);
       border-radius: 6px; padding: .5rem .65rem; margin-top: .75rem; }
     .rerun code { font-size: .8rem; word-break: break-all; }
+    .related-suites { border-style: dashed; background: transparent; }
+    .related-suites h3 { color: var(--muted); font-size: .95rem; }
     footer { margin-top: 2rem; font-size: .8125rem; color: var(--muted); text-align: center; }
     footer a { color: var(--accent); }
   </style>
@@ -210,6 +212,15 @@
           </tr>
         </tbody>
       </table>
+
+      <article class="scenario-card related-suites" id="c2-related-suites">
+        <h3>Related suites — not yet wired into the evidence flow</h3>
+        <p class="scenario-meta">These suites exist today; the status above is not derived from them.</p>
+        <ul class="evidence-links">
+          <li><a href="../../integrations/agntcy-slim/TopologyTest.md">TopologyTest.md</a> — topology routing (agntcy-slim)</li>
+        </ul>
+        <div class="rerun"><strong>Rerun (dev):</strong><br><code>task integrations:slim:test:topology</code></div>
+      </article>
     </section>
 
     <!-- C3 — Distributed -->
@@ -253,6 +264,19 @@
           </tr>
         </tbody>
       </table>
+
+      <article class="scenario-card related-suites" id="c3-related-suites">
+        <h3>Related suites — not yet wired into the evidence flow</h3>
+        <p class="scenario-meta">kind-slim-multi-host + integrations/kind-slim-multicluster — status above is not derived from these.</p>
+        <pre class="topology">cluster A: controller + root node
+cluster B: downstream node
+Link B → A: APPLIED · node B: Connected</pre>
+        <ul class="evidence-links">
+          <li><a href="../../integrations/kind-slim-multicluster/">Integration suite</a></li>
+          <li><a href="../../kind-slim-multi-host/README.md">KinD stack README</a></li>
+        </ul>
+        <div class="rerun"><strong>Rerun:</strong><br><code>CSIT_KIND_SLIM_MULTICLUSTER=1 go test ./integrations/kind-slim-multicluster/... -ginkgo.label-filter=kind-slim-multicluster</code></div>
+      </article>
     </section>
 
     <footer>

--- a/analitics/templates/dashboard.html.tmpl
+++ b/analitics/templates/dashboard.html.tmpl
@@ -192,10 +192,10 @@
       <p class="class-tag">C2 · Decentralized</p>
       <div class="class-head">
         <h2>Workflow or route graph coordinates agents</h2>
-        <span class="status status-planned">Evidence pending</span>
+        {{C2_CLASS_STATUS_SPAN}}
       </div>
       <p class="class-def">No single global brain, but coordination is scripted: a workflow manager or declared route graph defines who talks to whom and in what order. Agents follow the graph; autonomy is bounded by it.</p>
-      <p class="planned-note"><strong>Forthcoming.</strong> The use cases below define the target scenarios and the evidence each will produce once wired into the automated build. Status is <em>Evidence pending</em> until the related suites feed <code>c2-evidence.json</code>. Tracked in the <a href="../docs/plans/slim-dashboard-epic.md">SLIM dashboard epic</a> (post-July phase).</p>
+      {{C2_PLANNED_NOTE}}
 
       <table class="use-grid">
         <thead>
@@ -203,18 +203,27 @@
             <th>Use case</th>
             <th>SLIM mechanism</th>
             <th>Status</th>
-            <th>Expected evidence</th>
+            <th>Test / scenario</th>
+            <th>Evidence</th>
           </tr>
         </thead>
         <tbody>
           <tr id="c2-topology-routing">
             <td>
               <div class="use-name">Multi-agent flow over fixed, named routes</div>
-              <div class="use-meta">Messages traverse several SLIM servers by name (e.g. one agent waits while another sends through intermediate nodes)</div>
+              <div class="use-meta">Named endpoints across clusters with runtime-declared segments and links (<code>slimctl</code> route graph)</div>
             </td>
             <td><code>declarative routes</code></td>
-            <td><span class="status status-planned">Evidence pending</span></td>
-            <td class="use-meta">Per-hop delivery assertions: each message reaches the named SLIM servers in the declared order; success rate and observed hop path captured from topology-test logs.</td>
+            <td>{{C2_TOPOLOGY_STATUS_SPAN}}<div class="use-meta">{{C2_TOPOLOGY_SCENARIOS}} routing scenario(s)</div></td>
+            <td>TopologyTest Ginkgo<br><span class="use-meta">integrations/agntcy-slim/topology</span></td>
+            <td>
+              <ul class="evidence-links">
+                <li><a href="evidence/c2-evidence.json">JSON</a></li>
+                <li><a href="evidence/c2-evidence.md">Markdown</a></li>
+                <li><a href="evidence/c2-evidence.html">HTML</a></li>
+                <li><a href="../slim-integration/index.html">Ginkgo report</a></li>
+              </ul>
+            </td>
           </tr>
           <tr id="c2-workflow-app">
             <td>
@@ -223,18 +232,20 @@
             </td>
             <td><code>workflow + SLIM</code></td>
             <td><span class="status status-planned">Evidence pending</span></td>
-            <td class="use-meta">Step-completion proof: every workflow step's message is delivered and acknowledged; end-to-end run reported as successful by the workflow manager.</td>
+            <td>agntcy-apps campaigns<br><span class="use-meta">integrations/agntcy-apps</span></td>
+            <td class="use-meta">Step-completion proof once a workflow suite feeds <code>c2-evidence.json</code>.</td>
           </tr>
         </tbody>
       </table>
 
-      <article class="scenario-card related-suites" id="c2-related-suites">
-        <h3>Related suites — not yet wired into the evidence flow</h3>
-        <p class="scenario-meta">These suites exist today; the status above is not derived from them.</p>
+      <article class="scenario-card" id="c2-scenario-topology">
+        <h3>Test evidence: topology routing</h3>
+        <p class="scenario-meta">Multi-cluster · task integrations:slim:test:topology</p>
+        <p>Proves scripted multi-hop routing: segment isolation, dynamic link changes, and delivery after a dataplane gateway restart. Status for <code>c2-topology-routing</code> is read from <code>reports/c2-evidence.json</code> (three scenarios: isolated routes, linked routes, route survives restart).</p>
         <ul class="evidence-links">
-          <li><a href="../../integrations/agntcy-slim/TopologyTest.md">TopologyTest.md</a> — topology routing (agntcy-slim)</li>
+          <li><a href="../../integrations/agntcy-slim/TopologyTest.md">TopologyTest.md</a></li>
         </ul>
-        <div class="rerun"><strong>Rerun (dev):</strong><br><code>task integrations:slim:test:topology</code></div>
+        <div class="rerun"><strong>Rerun:</strong><br><code>task integrations:slim:test:topology</code><br><code>cp integrations/agntcy-slim/topology/reports/c2-evidence.json analitics/reports/</code><br><code>task -t analitics/Taskfile.yml dashboard:build:only</code></div>
       </article>
     </section>
 

--- a/analitics/templates/dashboard.html.tmpl
+++ b/analitics/templates/dashboard.html.tmpl
@@ -65,8 +65,36 @@
 
     <section>
       <h1>SLIM evidence by agentic system class</h1>
-      <p class="hero-lead"><strong>SLIM</strong> is the messaging layer for agent systems. This page maps CSIT test evidence to the agentic-system taxonomy: each <strong>class</strong> section lists related <strong>use cases</strong>, and each use case links to test-derived <strong>evidence</strong>.</p>
+      <p class="hero-lead"><strong>SLIM</strong> is the messaging layer for agent systems. This page maps CSIT test evidence to the agentic-system taxonomy: each <strong>class</strong> section lists related <strong>use cases</strong>, and each use case links to test-derived <strong>evidence</strong> where it is available.</p>
       <p class="meta">Last updated: {{GENERATED_AT}} · Contract: <a href="../docs/plans/slim-c1-evidence-contract-v1.md">C1 evidence v1</a> · <a href="https://github.com/agntcy/csit/discussions/195">Discussion #195</a></p>
+    </section>
+
+    <!-- Taxonomy explainer -->
+    <section id="taxonomy">
+      <h2>The agentic-system taxonomy</h2>
+      <p class="class-def">Agentic systems are grouped into three classes by <strong>who controls message flow and agent coordination</strong> — not by model vendor, language, or agent count.</p>
+      <table class="use-grid">
+        <thead>
+          <tr>
+            <th>Class</th>
+            <th>Definition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="class-tag">C1 · Centralized</span></td>
+            <td>A single authority — runtime, broker, or control plane — owns routing and invocation. Agents connect <em>through</em> it rather than negotiating peers or paths themselves.</td>
+          </tr>
+          <tr>
+            <td><span class="class-tag">C2 · Decentralized</span></td>
+            <td>No single global brain, but coordination is scripted: a workflow manager or declared route graph defines who talks to whom and in what order.</td>
+          </tr>
+          <tr>
+            <td><span class="class-tag">C3 · Distributed</span></td>
+            <td>Agents and dataplanes act as peers across hosts and clusters. Paths are established through control-plane links and policy, not a fixed workflow script.</td>
+          </tr>
+        </tbody>
+      </table>
     </section>
 
     <!-- C1 — Centralized -->
@@ -91,8 +119,8 @@
         <tbody>
           <tr id="c1-request-reply">
             <td>
-              <div class="use-name">Agent A calls B and waits for a reply</div>
-              <div class="use-meta">Named endpoints with synchronous round-trip on one node</div>
+              <div class="use-name">Agent calls another and waits for a reply</div>
+              <div class="use-meta">Synchronous round-trip between named endpoints on a single SLIM node</div>
             </td>
             <td><code>request-reply</code></td>
             <td>{{C1_RR_STATUS_SPAN}}<div class="use-meta">{{C1_RR_ROWS}} C1 evidence case(s)</div></td>
@@ -107,8 +135,8 @@
           </tr>
           <tr id="c1-fire-and-forget">
             <td>
-              <div class="use-name">Agent fires event; consumer handles async</div>
-              <div class="use-meta">One-way delivery through a single SLIM authority with sink observation</div>
+              <div class="use-name">Agent emits an event; a consumer handles it asynchronously</div>
+              <div class="use-meta">One-way delivery through a single SLIM node, observed at the sink</div>
             </td>
             <td><code>fire-and-forget</code></td>
             <td>{{C1_FF_STATUS_SPAN}}<div class="use-meta">{{C1_FF_ROWS}} C1 evidence case(s)</div></td>
@@ -123,8 +151,8 @@
           </tr>
           <tr id="c1-write">
             <td>
-              <div class="use-name">Publish into mesh without paired responder</div>
-              <div class="use-meta">Ingress/write path without a bound responder process</div>
+              <div class="use-name">Publish into the mesh without a paired responder</div>
+              <div class="use-meta">Write/ingress path with no bound responder process</div>
             </td>
             <td><code>write</code></td>
             <td>{{C1_W_STATUS_SPAN}}<div class="use-meta">{{C1_W_ROWS}} C1 evidence case(s)</div></td>
@@ -153,59 +181,35 @@
       <p class="class-tag">C2 · Decentralized</p>
       <div class="class-head">
         <h2>Workflow or route graph coordinates agents</h2>
-        <span class="status status-partial">Partial</span>
+        <span class="status status-planned">Evidence pending</span>
       </div>
-      <p class="class-def">No single global brain, but coordination is scripted: a workflow manager or declared route graph defines who talks to whom and in what order.</p>
+      <p class="class-def">No single global brain, but coordination is scripted: a workflow manager or declared route graph defines who talks to whom and in what order. Agents follow the graph; autonomy is bounded by it.</p>
+      <p class="use-meta">The use cases below define the target scenarios. Test-derived evidence is not yet available.</p>
 
       <table class="use-grid">
         <thead>
           <tr>
             <th>Use case</th>
             <th>SLIM mechanism</th>
-            <th>Status</th>
-            <th>Test / scenario</th>
-            <th>Evidence</th>
           </tr>
         </thead>
         <tbody>
           <tr id="c2-topology-routing">
             <td>
-              <div class="use-name">Multi-agent scenario with fixed routes (Alice/Bob)</div>
-              <div class="use-meta">Named multi-hop delivery across SLIM servers</div>
+              <div class="use-name">Multi-agent flow over fixed, named routes</div>
+              <div class="use-meta">Messages traverse several SLIM servers by name (e.g. one agent waits while another sends through intermediate nodes)</div>
             </td>
             <td><code>declarative routes</code></td>
-            <td><span class="status status-partial">Partial</span></td>
-            <td>Topology test<br><span class="use-meta">integrations/agntcy-slim</span></td>
-            <td>
-              <ul class="evidence-links">
-                <li><a href="../../integrations/agntcy-slim/TopologyTest.md">TopologyTest.md</a></li>
-                <li><span class="use-meta">Dashboard row: August</span></li>
-              </ul>
-            </td>
           </tr>
           <tr id="c2-workflow-app">
             <td>
-              <div class="use-name">Multi-step app driven by workflow manager</div>
-              <div class="use-meta">SLIM under external workflow steps</div>
+              <div class="use-name">Multi-step application driven by a workflow manager</div>
+              <div class="use-meta">An external workflow engine sequences the steps while SLIM carries messages between them</div>
             </td>
             <td><code>workflow + SLIM</code></td>
-            <td><span class="status status-planned">Planned</span></td>
-            <td>agntcy-apps campaigns<br><span class="use-meta">integrations/agntcy-apps</span></td>
-            <td>
-              <ul class="evidence-links">
-                <li><span class="use-meta">Narrative only — evidence TBD</span></li>
-              </ul>
-            </td>
           </tr>
         </tbody>
       </table>
-
-      <article class="scenario-card" id="c2-scenario-topology">
-        <h3>Test evidence: topology routing (planned integration)</h3>
-        <p class="scenario-meta">Multi-node · integrations/agntcy-slim topology Ginkgo suite</p>
-        <p>Will link topology test reports when wired into the analitics publish flow.</p>
-        <div class="rerun"><strong>Rerun (dev):</strong><br><code>task integrations:slim:test:topology</code></div>
-      </article>
     </section>
 
     <!-- C3 — Distributed -->
@@ -213,75 +217,42 @@
       <p class="class-tag">C3 · Distributed</p>
       <div class="class-head">
         <h2>Peers across clusters; control plane establishes links</h2>
-        <span class="status status-verified">Verified</span>
+        <span class="status status-planned">Evidence pending</span>
       </div>
-      <p class="class-def">Dataplanes operate as peers across hosts or clusters. Paths are established via control-plane links and policy, not a fixed workflow script.</p>
+      <p class="class-def">Agents and dataplanes act as peers across hosts, clusters, or org boundaries with no standing workflow script. Paths are established through control-plane links and policy, and the emphasis is on mesh membership and durability.</p>
+      <p class="use-meta">The use cases below define the target scenarios. Test-derived evidence is not yet available.</p>
 
       <table class="use-grid">
         <thead>
           <tr>
             <th>Use case</th>
             <th>SLIM mechanism</th>
-            <th>Status</th>
-            <th>Test / scenario</th>
-            <th>Evidence</th>
           </tr>
         </thead>
         <tbody>
           <tr id="c3-mesh-join">
             <td>
-              <div class="use-name">Downstream cluster joins controller mesh</div>
-              <div class="use-meta">Node Connected, link APPLIED B → A</div>
+              <div class="use-name">Downstream cluster joins the controller mesh</div>
+              <div class="use-meta">A dataplane on one cluster registers with the controller on another and the cross-cluster link is applied</div>
             </td>
             <td><code>controller link</code></td>
-            <td><span class="status status-verified">Verified</span></td>
-            <td>Multicluster controller link<br><span class="use-meta">kind-slim-multicluster</span></td>
-            <td>
-              <ul class="evidence-links">
-                <li><a href="../../integrations/kind-slim-multicluster/">Integration suite</a></li>
-                <li><a href="../../kind-slim-multi-host/README.md">KinD stack README</a></li>
-              </ul>
-            </td>
           </tr>
           <tr id="c3-link-persistence">
             <td>
-              <div class="use-name">Control plane survives rollout; same link ID</div>
-              <div class="use-meta">Link persistence after controller restart</div>
+              <div class="use-name">Control plane survives a rollout</div>
+              <div class="use-meta">The cross-cluster link keeps the same identity after the controller restarts</div>
             </td>
             <td><code>link persistence</code></td>
-            <td><span class="status status-verified">Verified</span></td>
-            <td>Same multicluster suite</td>
-            <td>
-              <ul class="evidence-links">
-                <li><a href="../../integrations/kind-slim-multicluster/">Integration suite</a></li>
-              </ul>
-            </td>
           </tr>
           <tr id="c3-autonomous-peers">
             <td>
-              <div class="use-name">Autonomous peers across hosts (no fixed WFSM)</div>
-              <div class="use-meta">Federation + optional routes</div>
+              <div class="use-name">Autonomous peers across hosts</div>
+              <div class="use-meta">Peers exchange messages across hosts or clusters without a fixed workflow, via federation and optional routes</div>
             </td>
             <td><code>federation</code></td>
-            <td><span class="status status-partial">Refine</span></td>
-            <td>Multicluster / peer-to-peer config</td>
-            <td>
-              <ul class="evidence-links">
-                <li><span class="use-meta">Evidence contract TBD</span></li>
-              </ul>
-            </td>
           </tr>
         </tbody>
       </table>
-
-      <article class="scenario-card" id="c3-scenario-multicluster">
-        <h3>Test evidence: multicluster controller link</h3>
-        <p class="scenario-meta">kind-slim-multi-host + integrations/kind-slim-multicluster</p>
-        <pre class="topology">cluster A: controller + root node
-cluster B: downstream node
-Link B → A: APPLIED · node B: Connected</pre>
-        <div class="rerun"><strong>Rerun:</strong><br><code>CSIT_KIND_SLIM_MULTICLUSTER=1 go test ./integrations/kind-slim-multicluster/... -ginkgo.label-filter=kind-slim-multicluster</code></div>
-      </article>
     </section>
 
     <footer>

--- a/analitics/templates/dashboard.html.tmpl
+++ b/analitics/templates/dashboard.html.tmpl
@@ -57,6 +57,10 @@
     .rerun code { font-size: .8rem; word-break: break-all; }
     .related-suites { border-style: dashed; background: transparent; }
     .related-suites h3 { color: var(--muted); font-size: .95rem; }
+    .planned-note { font-size: .9375rem; color: var(--partial); background: var(--partial-bg);
+      border: 1px solid #f0e0c0; border-radius: 8px; padding: .75rem 1rem; margin-bottom: 1.25rem; max-width: 72ch; }
+    .planned-note strong { color: var(--partial); }
+    .planned-note a { color: var(--accent); }
     footer { margin-top: 2rem; font-size: .8125rem; color: var(--muted); text-align: center; }
     footer a { color: var(--accent); }
   </style>
@@ -97,6 +101,11 @@
           </tr>
         </tbody>
       </table>
+      <p class="use-meta" style="margin-bottom:0">
+        <strong>Status legend:</strong>
+        <span class="status status-verified">Verified</span> assertion-backed test evidence exists ·
+        <span class="status status-planned">Evidence pending</span> use case defined; evidence not yet wired into the build.
+      </p>
     </section>
 
     <!-- C1 — Centralized -->
@@ -186,13 +195,15 @@
         <span class="status status-planned">Evidence pending</span>
       </div>
       <p class="class-def">No single global brain, but coordination is scripted: a workflow manager or declared route graph defines who talks to whom and in what order. Agents follow the graph; autonomy is bounded by it.</p>
-      <p class="use-meta">The use cases below define the target scenarios. Test-derived evidence is not yet available.</p>
+      <p class="planned-note"><strong>Forthcoming.</strong> The use cases below define the target scenarios and the evidence each will produce once wired into the automated build. Status is <em>Evidence pending</em> until the related suites feed <code>c2-evidence.json</code>. Tracked in the <a href="../docs/plans/slim-dashboard-epic.md">SLIM dashboard epic</a> (post-July phase).</p>
 
       <table class="use-grid">
         <thead>
           <tr>
             <th>Use case</th>
             <th>SLIM mechanism</th>
+            <th>Status</th>
+            <th>Expected evidence</th>
           </tr>
         </thead>
         <tbody>
@@ -202,6 +213,8 @@
               <div class="use-meta">Messages traverse several SLIM servers by name (e.g. one agent waits while another sends through intermediate nodes)</div>
             </td>
             <td><code>declarative routes</code></td>
+            <td><span class="status status-planned">Evidence pending</span></td>
+            <td class="use-meta">Per-hop delivery assertions: each message reaches the named SLIM servers in the declared order; success rate and observed hop path captured from topology-test logs.</td>
           </tr>
           <tr id="c2-workflow-app">
             <td>
@@ -209,6 +222,8 @@
               <div class="use-meta">An external workflow engine sequences the steps while SLIM carries messages between them</div>
             </td>
             <td><code>workflow + SLIM</code></td>
+            <td><span class="status status-planned">Evidence pending</span></td>
+            <td class="use-meta">Step-completion proof: every workflow step's message is delivered and acknowledged; end-to-end run reported as successful by the workflow manager.</td>
           </tr>
         </tbody>
       </table>
@@ -231,13 +246,15 @@
         <span class="status status-planned">Evidence pending</span>
       </div>
       <p class="class-def">Agents and dataplanes act as peers across hosts, clusters, or org boundaries with no standing workflow script. Paths are established through control-plane links and policy, and the emphasis is on mesh membership and durability.</p>
-      <p class="use-meta">The use cases below define the target scenarios. Test-derived evidence is not yet available.</p>
+      <p class="planned-note"><strong>Forthcoming.</strong> The use cases below define the target scenarios and the evidence each will produce once wired into the automated build. Status is <em>Evidence pending</em> until the related suites feed <code>c3-evidence.json</code>. Tracked in the <a href="../docs/plans/slim-dashboard-epic.md">SLIM dashboard epic</a> (post-July phase).</p>
 
       <table class="use-grid">
         <thead>
           <tr>
             <th>Use case</th>
             <th>SLIM mechanism</th>
+            <th>Status</th>
+            <th>Expected evidence</th>
           </tr>
         </thead>
         <tbody>
@@ -247,6 +264,8 @@
               <div class="use-meta">A dataplane on one cluster registers with the controller on another and the cross-cluster link is applied</div>
             </td>
             <td><code>controller link</code></td>
+            <td><span class="status status-planned">Evidence pending</span></td>
+            <td class="use-meta">Node reported <code>Connected</code> and the cross-cluster link reported <code>APPLIED</code>, captured from controller / <code>slimctl</code> state.</td>
           </tr>
           <tr id="c3-link-persistence">
             <td>
@@ -254,6 +273,8 @@
               <div class="use-meta">The cross-cluster link keeps the same identity after the controller restarts</div>
             </td>
             <td><code>link persistence</code></td>
+            <td><span class="status status-planned">Evidence pending</span></td>
+            <td class="use-meta">Same link ID observed before and after a controller restart; link remains <code>APPLIED</code> with no manual re-registration.</td>
           </tr>
           <tr id="c3-autonomous-peers">
             <td>
@@ -261,6 +282,8 @@
               <div class="use-meta">Peers exchange messages across hosts or clusters without a fixed workflow, via federation and optional routes</div>
             </td>
             <td><code>federation</code></td>
+            <td><span class="status status-planned">Evidence pending</span></td>
+            <td class="use-meta">Cross-host message exchange succeeds via federation without a fixed workflow script; delivery success recorded across peers.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/plans/slim-c2-evidence-contract-v1.md
+++ b/docs/plans/slim-c2-evidence-contract-v1.md
@@ -1,0 +1,116 @@
+# C2 evidence contract (v1) — topology routing slice
+
+**Status:** Draft for dashboard slice 2 (first C2 row)  
+**Epic:** [`slim-dashboard-epic.md`](slim-dashboard-epic.md)  
+**C1 reference:** [`slim-c1-evidence-contract-v1.md`](slim-c1-evidence-contract-v1.md)
+
+This document locks the first **C2** dashboard row (`c2-topology-routing`) and its evidence source. The analitics dashboard reads `c2-evidence.json` for row status; the Ginkgo HTML report under `docs/slim-integration/` remains supplementary detail.
+
+---
+
+## C2 use-case matrix (slice 2)
+
+| Row ID | Class | Use case (reader) | SLIM mechanism | CSIT scenario | Status source |
+|--------|-------|-------------------|----------------|---------------|---------------|
+| `c2-topology-routing` | **C2** | Multi-agent flow over fixed, named routes | `declarative-routes` | TopologyTest Ginkgo (`integrations/agntcy-slim/topology/tests`) | `c2-evidence.json` |
+| `c2-workflow-app` | **C2** | Multi-step app driven by workflow manager | `workflow + SLIM` | `integrations/agntcy-apps` (future) | static pending |
+
+---
+
+## Scenario anchor (topology routing)
+
+| Property | Value |
+|----------|--------|
+| Scenario name | TopologyTest Ginkgo |
+| Repo path | `integrations/agntcy-slim/topology/` |
+| CI workflow | `.github/workflows/test-slim-integration.yaml` |
+| CI task | `task integrations:slim:test:topology` |
+| Ginkgo focus | `Slim topology test` |
+| Evidence output | `integrations/agntcy-slim/topology/reports/c2-evidence.json` |
+| Detail report | `integrations/agntcy-slim/topology/reports/index.html` → Pages `docs/slim-integration/` |
+
+### C2 routing scenarios (in `c2-evidence.json`)
+
+| Scenario key | TopologyTest `When`/`Then` | Proof |
+|--------------|----------------------------|-------|
+| `isolated-routes` | Segments isolate b↔c; alice→bob and alice→carol | End-to-end delivery + negative isolation + link APPLIED state |
+| `linked-routes` | Add b↔c link | Bob→carol delivery after graph change |
+| `route-survives-restart` | Gateway pod restart on b↔c | Delivery after dataplane failover |
+
+**Out of scope for C2 row:** control-plane restart link persistence (reserved for future **C3** evidence).
+
+---
+
+## `c2-evidence.json` schema (v1)
+
+### Producer
+
+| Step | Location |
+|------|----------|
+| Run topology suite | `task integrations:slim:test:topology:run` with `C2_EVIDENCE_REPORT_DIR=<topology>/reports` |
+| Writer | `integrations/agntcy-slim/topology/tests/c2_evidence_report.go` |
+| Dashboard ingest | `analitics/scripts/evidence-lib.sh` → `row_status "c2-topology-routing" 3` |
+
+### Required fields per case
+
+| Field | Role |
+|-------|------|
+| `row_id` | Stable key (`c2-topology-routing`) |
+| `scenario` | Scenario slug (`isolated-routes`, `linked-routes`, `route-survives-restart`) |
+| `mechanism` | `declarative-routes` |
+| `status` | `verified` when the Ginkgo spec passes |
+| `assertions` | Human-readable behavioral proof lines |
+
+### Row status rules (dashboard)
+
+Apply in order (`analitics/scripts/evidence-lib.sh`):
+
+1. Read `c2-evidence.json` (from `analitics/reports/` or synced from topology reports).
+2. Filter cases where `row_id == c2-topology-routing`.
+3. Any `failed` → row **Failed**.
+4. Fewer than 3 `verified` scenarios and none failed → row **Partial**.
+5. Exactly 3 `verified` scenarios → row **Verified**.
+6. Missing file or cases → row **Unknown**.
+
+**C2 class badge:** **Partial** when topology row is verified (workflow row still pending); **Failed** if topology row failed; **Unknown** otherwise.
+
+---
+
+## Local workflow
+
+```bash
+# 1. Run topology test (KinD + controller + clusters required)
+task integrations:slim:test:topology
+
+# 2. Build dashboard (auto-syncs c2-evidence.json from topology reports)
+task -t analitics/Taskfile.yml dashboard:build:only
+
+# 3. Open
+open analitics/published/index.html
+```
+
+Manual sync override:
+
+```bash
+cp integrations/agntcy-slim/topology/reports/c2-evidence.json analitics/reports/
+C2_EVIDENCE_SOURCE=analitics/reports/c2-evidence.json task -t analitics/Taskfile.yml dashboard:build:only
+```
+
+---
+
+## Pages / CI wiring
+
+| Artifact | Contents |
+|----------|----------|
+| `slim-integration-test-result` | `report-slim-topology.json`, `c2-evidence.json`, `index.html`, … |
+| `agentic-evidence-dashboard` | `published/index.html`, `published/evidence/c1-evidence.*`, `published/evidence/c2-evidence.*` |
+
+The `test-agentic-evidence` workflow attempts to download `slim-integration-test-result` from the same commit before rendering so C2 status appears on `docs/agentic-evidence/` when both suites ran on that SHA.
+
+---
+
+## References
+
+- [`TopologyTest.md`](../../integrations/agntcy-slim/topology/TopologyTest.md)
+- Dashboard template: `analitics/templates/dashboard.html.tmpl`
+- Topology evidence writer: `integrations/agntcy-slim/topology/tests/topology_test.go`

--- a/integrations/agntcy-slim/topology/Taskfile.yml
+++ b/integrations/agntcy-slim/topology/Taskfile.yml
@@ -280,7 +280,7 @@ tasks:
           /*) : ;;
           *) SLIMCTL_BIN="$(pwd)/${SLIMCTL_BIN#./}" ;;
         esac
-        NAMESPACE={{.HELM_NAMESPACE}} TOPOLOGY_CONFIG=../{{.TOPOLOGY_CONFIG}} SLIMCTL="$SLIMCTL_BIN" SLIMCTL_SERVER="http://127.0.0.1:50051" CLIENT_IMAGE="{{ .CLIENT_IMAGE }}" \
+        NAMESPACE={{.HELM_NAMESPACE}} TOPOLOGY_CONFIG=../{{.TOPOLOGY_CONFIG}} SLIMCTL="$SLIMCTL_BIN" SLIMCTL_SERVER="http://127.0.0.1:50051" CLIENT_IMAGE="{{ .CLIENT_IMAGE }}" C2_EVIDENCE_REPORT_DIR="$(pwd)/reports" \
           go test ./tests -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 30m -timeout 30m -ginkgo.v -ginkgo.focus "Slim topology test" --ginkgo.json-report=../reports/report-slim-topology.json --ginkgo.junit-report=../reports/report-slim-topology.xml
 
   test:topology:report:

--- a/integrations/agntcy-slim/topology/tests/c2_evidence_report.go
+++ b/integrations/agntcy-slim/topology/tests/c2_evidence_report.go
@@ -1,0 +1,112 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const c2EvidenceSchemaVersion = "1"
+
+type c2EvidenceDocument struct {
+	SchemaVersion string           `json:"schema_version"`
+	GeneratedAt   string           `json:"generated_at"`
+	Source        string           `json:"source"`
+	Cases         []c2EvidenceCase `json:"cases"`
+}
+
+type c2EvidenceCase struct {
+	RowID      string   `json:"row_id"`
+	Scenario   string   `json:"scenario"`
+	Mechanism  string   `json:"mechanism"`
+	UseCase    string   `json:"use_case"`
+	Status     string   `json:"status"`
+	Assertions []string `json:"assertions"`
+}
+
+func c2EvidenceReportPath() string {
+	reportDir := os.Getenv("C2_EVIDENCE_REPORT_DIR")
+	if reportDir == "" {
+		reportDir = "../reports"
+	}
+	absDir, err := filepath.Abs(reportDir)
+	if err != nil {
+		panic(fmt.Sprintf("resolve C2 evidence report dir: %v", err))
+	}
+	return filepath.Join(absDir, "c2-evidence.json")
+}
+
+func loadC2EvidenceDocument(path string) (c2EvidenceDocument, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return c2EvidenceDocument{}, err
+	}
+	var doc c2EvidenceDocument
+	if err := json.Unmarshal(content, &doc); err != nil {
+		return c2EvidenceDocument{}, err
+	}
+	return doc, nil
+}
+
+func writeC2EvidenceDocument(path string, cases []c2EvidenceCase) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	doc := c2EvidenceDocument{
+		SchemaVersion: c2EvidenceSchemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        "integrations/agntcy-slim/topology/tests/topology_test.go",
+		Cases:         cases,
+	}
+
+	encoded, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	return os.WriteFile(path, encoded, 0o644)
+}
+
+func upsertC2EvidenceCase(path string, row c2EvidenceCase) error {
+	doc, err := loadC2EvidenceDocument(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		doc = c2EvidenceDocument{
+			SchemaVersion: c2EvidenceSchemaVersion,
+			Source:        "integrations/agntcy-slim/topology/tests/topology_test.go",
+		}
+	}
+
+	updated := false
+	for idx, existing := range doc.Cases {
+		if existing.RowID == row.RowID && existing.Scenario == row.Scenario {
+			doc.Cases[idx] = row
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		doc.Cases = append(doc.Cases, row)
+	}
+
+	doc.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	return writeC2EvidenceDocument(path, doc.Cases)
+}
+
+func logC2EvidenceSummary(row c2EvidenceCase) {
+	fmt.Printf(
+		"C2_EVIDENCE row_id=%s scenario=%s status=%s assertions=%d\n",
+		row.RowID,
+		row.Scenario,
+		row.Status,
+		len(row.Assertions),
+	)
+}

--- a/integrations/agntcy-slim/topology/tests/c2_evidence_report_test.go
+++ b/integrations/agntcy-slim/topology/tests/c2_evidence_report_test.go
@@ -1,0 +1,54 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestWriteAndLoadC2EvidenceDocument(t *testing.T) {
+	gomega.RegisterFailHandler(func(message string, callerSkip ...int) {
+		t.Helper()
+		t.Fatal(message)
+	})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "c2-evidence.json")
+
+	row := c2EvidenceCase{
+		RowID:     "c2-topology-routing",
+		Scenario:  "isolated-routes",
+		Mechanism: "declarative-routes",
+		UseCase:   "Multi-agent flow over fixed, named routes",
+		Status:    "verified",
+		Assertions: []string{
+			"alice delivered to bob",
+		},
+	}
+
+	gomega.Expect(upsertC2EvidenceCase(path, row)).To(gomega.Succeed())
+
+	loaded, err := loadC2EvidenceDocument(path)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(loaded.SchemaVersion).To(gomega.Equal("1"))
+	gomega.Expect(loaded.Cases).To(gomega.HaveLen(1))
+	gomega.Expect(loaded.Cases[0].Scenario).To(gomega.Equal("isolated-routes"))
+
+	updated := row
+	updated.Status = "failed"
+	gomega.Expect(upsertC2EvidenceCase(path, updated)).To(gomega.Succeed())
+
+	loaded, err = loadC2EvidenceDocument(path)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(loaded.Cases).To(gomega.HaveLen(1))
+	gomega.Expect(loaded.Cases[0].Status).To(gomega.Equal("failed"))
+
+	content, err := os.ReadFile(path)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(string(content)).To(gomega.ContainSubstring("\"row_id\": \"c2-topology-routing\""))
+}

--- a/integrations/agntcy-slim/topology/tests/topology_test.go
+++ b/integrations/agntcy-slim/topology/tests/topology_test.go
@@ -281,6 +281,20 @@ func interClusterLinkApplied(links []linkEntry, clusterA, clusterB string) bool 
 // connectedLinksBetween counts links connecting clusterA and clusterB whose
 // endpoints are both currently Connected. This ignores stale links left behind
 // on Unknown nodes after a restart, unlike linksBetween.
+func recordC2TopologyEvidence(scenario string, assertions []string) {
+	row := c2EvidenceCase{
+		RowID:      "c2-topology-routing",
+		Scenario:   scenario,
+		Mechanism:  "declarative-routes",
+		UseCase:    "Multi-agent flow over fixed, named routes",
+		Status:     "verified",
+		Assertions: assertions,
+	}
+	gomega.Expect(upsertC2EvidenceCase(c2EvidenceReportPath(), row)).To(gomega.Succeed())
+	logC2EvidenceSummary(row)
+	ginkgo.AddReportEntry("C2 Evidence", row.Scenario+"="+row.Status)
+}
+
 func connectedLinksBetween(links []linkEntry, connected map[string]bool, clusterA, clusterB string) int {
 	n := 0
 	for _, l := range links {
@@ -443,6 +457,15 @@ var _ = ginkgo.Describe("Agntcy slim topology test", func() {
 				gomega.Expect(interClusterLinkApplied(links, "cluster-a", "cluster-b")).To(gomega.BeTrue(), "cluster-a<->cluster-b link not applied")
 				gomega.Expect(interClusterLinkApplied(links, "cluster-a", "cluster-c")).To(gomega.BeTrue(), "cluster-a<->cluster-c link not applied")
 				gomega.Expect(interClusterLinkApplied(links, "cluster-b", "cluster-c")).To(gomega.BeFalse(), "unexpected cluster-b<->cluster-c link")
+
+				recordC2TopologyEvidence("isolated-routes", []string{
+					fmt.Sprintf("alice delivered to bob (received: %s)", msgFromAlice),
+					fmt.Sprintf("alice delivered to carol (received: %s)", msgFromAlice),
+					fmt.Sprintf("bob blocked from carol across isolated segments (no received: %s)", msgFromBob),
+					"cluster-a<->cluster-b link APPLIED",
+					"cluster-a<->cluster-c link APPLIED",
+					"no cluster-b<->cluster-c link while segments are isolated",
+				})
 			})
 		})
 
@@ -466,6 +489,11 @@ var _ = ginkgo.Describe("Agntcy slim topology test", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(found).To(gomega.BeTrue(), "carol did not receive bob's message after linking")
 				ginkgo.GinkgoWriter.Printf("carol received: %s\n", line)
+
+				recordC2TopologyEvidence("linked-routes", []string{
+					"cluster-b<->cluster-c link APPLIED after topology change",
+					fmt.Sprintf("bob delivered to carol after link added (received: %s)", msgFromBob),
+				})
 			})
 		})
 
@@ -532,6 +560,11 @@ var _ = ginkgo.Describe("Agntcy slim topology test", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(found).To(gomega.BeTrue(), "carol did not receive bob's message after node restart")
 				ginkgo.GinkgoWriter.Printf("carol received after restart: %s\n", line)
+
+				recordC2TopologyEvidence("route-survives-restart", []string{
+					"gateway node restart: b<->c link restored on a live cluster-b node",
+					fmt.Sprintf("bob delivered to carol after gateway restart (received: %s)", msgFromBobVerify),
+				})
 			})
 		})
 


### PR DESCRIPTION
Summary
Refines the agentic evidence dashboard and wires the first C2 proof path.

Dashboard (C1/C2/C3): Adds taxonomy context and honest status semantics. C2/C3 no longer claim verified evidence prematurely; related suites are linked separately. C1 status still comes from c1-evidence.json.

C2 evidence (new): TopologyTest now emits c2-evidence.json for three routing scenarios (isolated routes, linked routes, restart recovery). The analitics pipeline syncs, renders detail pages, and drives live dashboard status for c2-topology-routing. Contract: docs/plans/slim-c2-evidence-contract-v1.md. CI pulls topology artifacts into test-agentic-evidence when available.

Topology test: Refactored for v2.0 control-plane API mode — runtime slimctl topology, LoadBalancer northbound API, p2p client routing assertions, recovery scenarios.